### PR TITLE
docs: improve README/doc flow and link live examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ That's it. Zero config required — all rules are enabled by default.
 
 ---
 
+## Documentation Map
+
+- Rule behavior and schema-aware internals: [`docs/schema-drift.md`](docs/schema-drift.md)
+- Suppression patterns (inline, per-rule, exclusions): [`docs/suppression.md`](docs/suppression.md)
+- CI reviewer workflow and non-blocking mode: [`docs/ci-reviewer-mode.md`](docs/ci-reviewer-mode.md)
+- Output contracts (`terminal`, `json`, `sarif`): [`docs/output-formats.md`](docs/output-formats.md)
+
+## End-to-End Example PRs
+
+Live demos in [`ValkDB/valk-guard-example`](https://github.com/ValkDB/valk-guard-example):
+
+- Dist 1 (`VG001`-`VG003`): https://github.com/ValkDB/valk-guard-example/pull/2
+- Dist 2 (`VG004`-`VG006`): https://github.com/ValkDB/valk-guard-example/pull/3
+- Dist 3 (`VG007`, `VG008`, `VG101`-`VG105`): https://github.com/ValkDB/valk-guard-example/pull/4
+- Dist 4 (`VG106`-`VG111`): https://github.com/ValkDB/valk-guard-example/pull/5
+- Suppression showcase (inline + global): https://github.com/ValkDB/valk-guard-example/pull/6
+
+---
+
 ## What It Catches
 
 Valk Guard ships with **19 rules** across three categories:
@@ -94,6 +113,20 @@ Grab a pre-built binary from [GitHub Releases](https://github.com/ValkDB/valk-gu
 ```bash
 go install github.com/valkdb/valk-guard/cmd/valk-guard@latest
 ```
+
+### Install in CI (Recommended: Pin Version)
+
+For reproducible CI output and stable downstream processing, pin a release tag (or commit):
+
+```bash
+go install github.com/valkdb/valk-guard/cmd/valk-guard@vX.Y.Z
+```
+
+Why pin in CI:
+
+- avoids unexpected behavior changes from `@latest`
+- keeps output processing steps (for example jq/reviewdog conversion) stable
+- makes build and review results reproducible across reruns
 
 ### Build From Source
 

--- a/docs/ci-reviewer-mode.md
+++ b/docs/ci-reviewer-mode.md
@@ -33,6 +33,8 @@ permissions:
 This keeps CI non-blocking for findings (`exit 1`) while still posting review comments and preserving machine-readable output.
 Exit code `1` (findings detected) is treated as non-fatal; only exit code `2` or higher (config/runtime error) fails the step.
 
+For CI reproducibility, prefer pinning the install target to a version/tag instead of `@latest`.
+
 ## Full Example Workflow (Install + JSON + SARIF)
 
 ```yaml
@@ -47,6 +49,10 @@ permissions:
   pull-requests: write
   security-events: write
 
+env:
+  # Pin in CI for stable behavior and repeatable output processing.
+  VALK_GUARD_INSTALL_REF: vX.Y.Z
+
 jobs:
   scan:
     runs-on: ubuntu-latest
@@ -59,7 +65,7 @@ jobs:
           go-version: "1.25.6"
 
       - name: Install valk-guard
-        run: go install github.com/valkdb/valk-guard/cmd/valk-guard@latest
+        run: go install github.com/valkdb/valk-guard/cmd/valk-guard@${VALK_GUARD_INSTALL_REF}
 
       - name: Collect changed files
         id: changed
@@ -100,6 +106,15 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: valk-guard.sarif
+```
+
+## JSON Envelope Note (jq / reviewdog converters)
+
+`--format json` emits a versioned envelope (`version`, `findings`, `summary`).
+If you post-process with `jq`, normalize input before iterating findings:
+
+```bash
+jq -cr '((if type == "array" then . else .findings end) // [])[]'
 ```
 
 ## Changed-Files-Only Pattern (Recommended for PRs)

--- a/docs/schema-drift.md
+++ b/docs/schema-drift.md
@@ -5,6 +5,13 @@ Valk Guard builds a migration schema snapshot and runs two schema-aware checks:
 1. Model schema checks (`VG101`-`VG104`, `VG109`-`VG111`)
 2. Query-schema checks (`VG105`-`VG108`)
 
+## Live Demo PRs
+
+End-to-end schema-aware demos in `valk-guard-example`:
+
+- Dist 3 (`VG007`, `VG008`, `VG101`-`VG105`): https://github.com/ValkDB/valk-guard-example/pull/4
+- Dist 4 (`VG106`-`VG111`): https://github.com/ValkDB/valk-guard-example/pull/5
+
 ## How It Works
 
 Schema-aware detection runs as a post-scan phase:

--- a/docs/suppression.md
+++ b/docs/suppression.md
@@ -2,6 +2,18 @@
 
 Valk Guard supports multiple suppression levels so teams can tune signal vs noise without disabling the tool.
 
+## Live Demo
+
+A complete working suppression showcase (inline + global) lives in:
+
+- https://github.com/ValkDB/valk-guard-example/pull/6
+
+That PR includes:
+
+- query-level rule-specific suppression (`valk-guard:disable VG001`)
+- query-level disable-all suppression (`valk-guard:disable`)
+- global rule disable config (`rules.VG001.enabled: false`)
+
 ## 1) Per-File Exclusions
 
 Use `exclude` in `.valk-guard.yaml` to skip whole paths (for example generated files or migrations):


### PR DESCRIPTION
## Why

Improve `README` and docs structure for open-source onboarding clarity:
- clearer top-level doc navigation
- explicit local vs CI install guidance (pin in CI)
- direct links to live end-to-end example PRs
- explicit JSON envelope note for jq/reviewdog conversion tooling

## What Changed

- `README.md`
  - added Documentation Map
  - added End-to-End Example PR links (dist + suppression)
  - added CI install pin guidance and rationale
- `docs/ci-reviewer-mode.md`
  - added CI pin recommendation in workflow example
  - added JSON envelope normalization note for jq/reviewdog converters
- `docs/suppression.md`
  - linked live suppression showcase PR
- `docs/schema-drift.md`
  - linked live schema-aware demo PRs

## Outcome

Docs now better answer the common open-source onboarding questions:
- what it does
- where to start
- how to install locally vs CI
- where to see real working examples