### PR TITLE
feat: add C# EF Core raw SQL scanner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,14 @@ jobs:
         with:
           dotnet-version: '8.0.404'
 
+      - name: Cache NuGet packages
+        uses: actions/cache@0637707758659e81f5f0c2bb7b1d276a4737b6e0 # v4.3.0
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('valk-guard/internal/scanner/csharp/roslynextractor/**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
       - name: Verify Python
         run: python3 --version
 
@@ -67,6 +75,10 @@ jobs:
           VALK_REQUIRE_DOTNET: '1'
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
 
+      - name: Run Roslyn extractor tests
+        working-directory: valk-guard
+        run: dotnet test internal/scanner/csharp/roslynextractor/RoslynExtractor.Tests/RoslynExtractor.Tests.csproj --nologo
+
       - name: Print coverage
         working-directory: valk-guard
         run: go tool cover -func=coverage.out
@@ -76,6 +88,41 @@ jobs:
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
           govulncheck ./...
+
+  csharp-windows:
+    name: C# Scanner (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: valk-guard
+
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: '1.25.8'
+          cache-dependency-path: valk-guard/go.sum
+
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: '8.0.404'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@0637707758659e81f5f0c2bb7b1d276a4737b6e0 # v4.3.0
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('valk-guard/internal/scanner/csharp/roslynextractor/**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Run C# scanner tests
+        working-directory: valk-guard
+        env:
+          VALK_REQUIRE_DOTNET: '1'
+        run: go test ./internal/scanner/csharp
+
+      - name: Run Roslyn extractor tests
+        working-directory: valk-guard
+        run: dotnet test internal/scanner/csharp/roslynextractor/RoslynExtractor.Tests/RoslynExtractor.Tests.csproj --nologo
 
   self-scan:
     name: Self-scan
@@ -98,6 +145,14 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: '8.0.404'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@0637707758659e81f5f0c2bb7b1d276a4737b6e0 # v4.3.0
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('valk-guard/internal/scanner/csharp/roslynextractor/**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
 
       - name: Build valk-guard
         working-directory: valk-guard
@@ -140,6 +195,14 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: '8.0.404'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@0637707758659e81f5f0c2bb7b1d276a4737b6e0 # v4.3.0
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('valk-guard/internal/scanner/csharp/roslynextractor/**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
 
       - name: Build valk-guard
         working-directory: valk-guard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,20 @@ jobs:
         with:
           python-version: '3.12'
 
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: '8.0.404'
+
       - name: Verify Python
         run: python3 --version
 
+      - name: Verify .NET
+        run: dotnet --info
+
       - name: Run tests
         working-directory: valk-guard
+        env:
+          VALK_REQUIRE_DOTNET: '1'
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Print coverage
@@ -85,6 +94,10 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
+
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: '8.0.404'
 
       - name: Build valk-guard
         working-directory: valk-guard
@@ -124,6 +137,10 @@ jobs:
         with:
           python-version: '3.12'
 
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: '8.0.404'
+
       - name: Build valk-guard
         working-directory: valk-guard
         run: go build -ldflags "-s -w -X main.version=${GITHUB_SHA}" -o valk-guard ./cmd/valk-guard/
@@ -135,7 +152,7 @@ jobs:
           base_sha="${{ github.event.pull_request.base.sha }}"
           head_sha="${{ github.event.pull_request.head.sha }}"
 
-          files="$(git diff --name-only --diff-filter=ACMRT "$base_sha" "$head_sha" | grep -E '\.(sql|go|py)$' || true)"
+          files="$(git diff --name-only --diff-filter=ACMRT "$base_sha" "$head_sha" | grep -E '\.(sql|go|py|cs)$' || true)"
 
           if [ -z "$files" ]; then
             echo "has_files=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,10 @@ jobs:
           dotnet-version: '8.0.404'
 
       - name: Cache NuGet packages
-        uses: actions/cache@0637707758659e81f5f0c2bb7b1d276a4737b6e0 # v4.3.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('valk-guard/internal/scanner/csharp/roslynextractor/**/*.csproj') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('internal/scanner/csharp/roslynextractor/**/*.csproj') }}
           restore-keys: |
             nuget-${{ runner.os }}-
 
@@ -107,10 +107,10 @@ jobs:
           dotnet-version: '8.0.404'
 
       - name: Cache NuGet packages
-        uses: actions/cache@0637707758659e81f5f0c2bb7b1d276a4737b6e0 # v4.3.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('valk-guard/internal/scanner/csharp/roslynextractor/**/*.csproj') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('internal/scanner/csharp/roslynextractor/**/*.csproj') }}
           restore-keys: |
             nuget-${{ runner.os }}-
 
@@ -147,10 +147,10 @@ jobs:
           dotnet-version: '8.0.404'
 
       - name: Cache NuGet packages
-        uses: actions/cache@0637707758659e81f5f0c2bb7b1d276a4737b6e0 # v4.3.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('valk-guard/internal/scanner/csharp/roslynextractor/**/*.csproj') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('internal/scanner/csharp/roslynextractor/**/*.csproj') }}
           restore-keys: |
             nuget-${{ runner.os }}-
 
@@ -197,10 +197,10 @@ jobs:
           dotnet-version: '8.0.404'
 
       - name: Cache NuGet packages
-        uses: actions/cache@0637707758659e81f5f0c2bb7b1d276a4737b6e0 # v4.3.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('valk-guard/internal/scanner/csharp/roslynextractor/**/*.csproj') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('internal/scanner/csharp/roslynextractor/**/*.csproj') }}
           restore-keys: |
             nuget-${{ runner.os }}-
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,13 @@ jobs:
         with:
           python-version: '3.12'
 
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: '8.0.404'
+
       - name: Run tests
+        env:
+          VALK_REQUIRE_DOTNET: '1'
         run: go test -race ./...
 
       - name: Run GoReleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,21 @@ jobs:
         with:
           dotnet-version: '8.0.404'
 
+      - name: Cache NuGet packages
+        uses: actions/cache@0637707758659e81f5f0c2bb7b1d276a4737b6e0 # v4.3.0
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('internal/scanner/csharp/roslynextractor/**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
       - name: Run tests
         env:
           VALK_REQUIRE_DOTNET: '1'
         run: go test -race ./...
+
+      - name: Run Roslyn extractor tests
+        run: dotnet test internal/scanner/csharp/roslynextractor/RoslynExtractor.Tests/RoslynExtractor.Tests.csproj --nologo
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           dotnet-version: '8.0.404'
 
       - name: Cache NuGet packages
-        uses: actions/cache@0637707758659e81f5f0c2bb7b1d276a4737b6e0 # v4.3.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('internal/scanner/csharp/roslynextractor/**/*.csproj') }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ temp/
 
 # Claude Code local settings (personal tool permissions and local dev paths)
 .claude/settings.local.json
+/internal/scanner/csharp/roslynextractor/bin/*
+/internal/scanner/csharp/roslynextractor/obj/*
+/internal/scanner/csharp/roslynextractor/**/bin/*
+/internal/scanner/csharp/roslynextractor/**/obj/*

--- a/.valk-guard.yaml.example
+++ b/.valk-guard.yaml.example
@@ -21,6 +21,15 @@ migration_paths:
   - "db/migrations"
   - "schema/**/*.sql"
 
+# Optional source scanner/model-extractor switches. Missing entries default to true.
+# Disable csharp if .NET is unavailable, or sqlalchemy if Python scanning is not desired.
+sources:
+  sql: true
+  go: true
+  goqu: true
+  sqlalchemy: true # aliases: python, py
+  csharp: true     # aliases: cs, c#, dotnet
+
 # Go model extraction behavior
 go_model:
   # strict | balanced | permissive

--- a/.valk-guard.yaml.example
+++ b/.valk-guard.yaml.example
@@ -46,7 +46,7 @@ rules:
   # Query-schema examples
   VG105:
     severity: error
-    engines: [goqu, sqlalchemy]
+    engines: [goqu, sqlalchemy, csharp]
   VG106:
     severity: error
-    engines: [goqu, sqlalchemy]
+    engines: [goqu, sqlalchemy, csharp]

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ make install
 
 - **Go >= 1.25.8** for building from source
 - **Python >= 3.6** only when scanning `.py` files for SQLAlchemy usage. No pip packages needed — Valk Guard ships an embedded script using only stdlib (`ast`, `json`). If SQLAlchemy candidate files are present and `python3` is missing or too old, the scan fails fast with an error.
-- **.NET SDK >= 8.0** only when scanning C# files containing EF Core markers. The scanner uses an embedded Roslyn extractor and is not invoked for projects without C# EF Core candidates. Disable it with `sources.csharp: false` if needed.
+- **.NET SDK >= 8.0** only when scanning `.cs` files. The scanner sends C# files to an embedded Roslyn extractor so candidate detection is syntax-based instead of substring-based. Disable it with `sources.csharp: false` if needed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
 
 ## Why Valk Guard?
 
-**Most SQL linters use regex and only see raw `.sql` files. Valk Guard compiles your code and walks the AST.**
+**Most SQL linters use regex and only see raw `.sql` files. Valk Guard parses real source structure instead.**
 
-It reads Goqu builder chains, SQLAlchemy ORM calls, and Go `db.Query` invocations — not by pattern-matching strings, but by parsing the actual abstract syntax tree. It synthesizes SQL from your ORM code, feeds it through a real PostgreSQL grammar, and runs every rule against it.
+It reads Goqu builder chains, SQLAlchemy ORM calls, Go `db.Query` invocations, and C# EF Core `ExecuteSqlRaw` calls with source-aware scanners — Go and Python via AST, C# v1 via conservative text analysis of raw EF Core execution patterns. It synthesizes SQL from your ORM code, feeds it through a real PostgreSQL grammar, and runs every rule against it.
 
 That means: if your ORM builds a `DELETE` without a `WHERE`, Valk Guard catches it — even though no raw SQL exists anywhere in your source.
 
@@ -106,9 +106,9 @@ Valk Guard ships with **19 rules** across three categories. Here are the highlig
 
 ---
 
-## Not Regex — Real AST Analysis
+## Not Regex — Source-Aware Analysis
 
-Most SQL linters use regex. Valk Guard **compiles and walks the actual AST** of your Go and Python code. It understands ORM builder chains as first-class SQL — no raw strings required.
+Most SQL linters use regex. Valk Guard **walks real source structure** instead. It compiles and walks the actual AST of your Go and Python code, and for C# v1 it uses conservative text analysis of EF Core raw SQL execution calls. It understands ORM builder chains and raw execution APIs as first-class SQL sources — no `.sql` file required.
 
 <table>
 <tr>
@@ -137,7 +137,7 @@ Most SQL linters use regex. Valk Guard **compiles and walks the actual AST** of 
 </tr>
 </table>
 
-No raw SQL in those files. Valk Guard synthesizes SQL from the ORM calls, parses it with a PostgreSQL grammar, and runs all 19 rules against it (a handful of checks use targeted regex on parser-extracted clauses when the AST doesn't expose the needed field, but source scanning is always AST-based).
+No raw SQL in those files. Valk Guard synthesizes SQL from the ORM calls, parses it with a PostgreSQL grammar, and runs all 19 rules against it (a handful of checks use targeted regex on parser-extracted clauses when the AST doesn't expose the needed field; Go/Python source scanning is AST-based, while C# v1 uses conservative text analysis for EF Core raw SQL execution).
 
 | Source | How it works |
 |--------|-------------|
@@ -145,8 +145,11 @@ No raw SQL in those files. Valk Guard synthesizes SQL from the ORM calls, parses
 | **Go** (`go/ast`) | Extracts SQL from `db.Query`, `db.Exec`, `db.QueryRow` and context variants |
 | **Goqu** | Walks builder chains (`From`/`Join`/`Where`/`Limit`/`ForUpdate`) via Go AST |
 | **SQLAlchemy** | Parses ORM chains (`query`/`select`/`join`/`filter`) via Python AST |
+| **C# (EF Core)** | Extracts SQL from `ExecuteSqlRaw`, `ExecuteSqlInterpolated` and async variants via conservative text analysis |
 
 For schema-drift rules (VG101+), it also reads **ORM model definitions** — Go struct tags (`db`, `gorm`) and Python `__tablename__` / `Column(...)` — and cross-references them against your migration DDL.
+
+> **C# note:** v1 covers raw EF Core SQL execution only (`ExecuteSqlRaw`, `ExecuteSqlInterpolated`, and async variants). Query-builder and LINQ patterns are tracked separately.
 
 ---
 
@@ -155,7 +158,7 @@ For schema-drift rules (VG101+), it also reads **ORM model definitions** — Go 
 | | Valk Guard | SQL formatters/linters | DB-connected advisors | Schema-only drift checks |
 |---|---|---|---|---|
 | **Needs a running database** | No | Usually no | Usually yes | Usually no |
-| **Scans app source (`.go`, `.py`)** | Yes | Rarely | No | Rarely |
+| **Scans app source (`.go`, `.py`, `.cs`)** | Yes | Rarely | No | Rarely |
 | **Understands ORM/query builders** | Yes | Rarely | No | Sometimes |
 | **Checks schema drift against models** | Yes | Rarely | Sometimes | Yes |
 | **Fits PR review workflows** | Yes | Often | Sometimes | Often |
@@ -288,6 +291,7 @@ make install
 
 - **Go >= 1.25.8** for building from source
 - **Python >= 3.6** only when scanning `.py` files for SQLAlchemy usage. No pip packages needed — Valk Guard ships an embedded script using only stdlib (`ast`, `json`). If scanned `.py` files are present and `python3` is missing or too old, the scan fails fast with an error.
+- **No external runtime** for C# scanning — the EF Core scanner is a pure Go text-based analyzer, no .NET SDK required.
 
 ---
 
@@ -310,7 +314,7 @@ migration_paths:
 rules:
   VG001:
     severity: warning
-    engines: [all]       # all | sql | go | goqu | sqlalchemy
+    engines: [all]       # all | sql | go | goqu | sqlalchemy | csharp
   VG007:
     enabled: false
 
@@ -327,7 +331,7 @@ Reference: [`.valk-guard.yaml.example`](.valk-guard.yaml.example)
 SELECT * FROM users;
 ```
 
-Works in Go (`//`) and Python (`#`) too. Full guide: [`docs/suppression.md`](docs/suppression.md)
+Works in Go (`//`), Python (`#`), and C# (`//`) too. Full guide: [`docs/suppression.md`](docs/suppression.md)
 
 ### Exit Codes
 
@@ -348,6 +352,7 @@ flowchart LR
     A2["Go code"]
     A3["Goqu usage"]
     A4["Python SQLAlchemy"]
+    A5["C# EF Core"]
   end
 
   subgraph S2["2. Statement Extraction"]
@@ -355,6 +360,7 @@ flowchart LR
     B2["Go AST Scanner"]
     B3["Goqu Scanner"]
     B4["SQLAlchemy Scanner"]
+    B6["C# EF Core Scanner"]
     B5["Statements with file/line mapping"]
   end
 
@@ -384,6 +390,7 @@ flowchart LR
   A2 --> B2 --> B5
   A3 --> B3 --> B5
   A4 --> B4 --> B5
+  A5 --> B6 --> B5
 
   B5 --> C1
   C1 --> D1
@@ -412,6 +419,7 @@ flowchart LR
 
 Track progress and vote on what matters to you:
 
+- C# EF Core query-builder support — `FromSqlRaw`, `SqlQueryRaw`, LINQ patterns
 - GORM scanner — AST-based scanning for GORM builder chains and model extraction
 - Deeper builder semantics — aliases, nested subqueries, richer predicate trees
 - SQLAlchemy 2.0 `mapped_column()` support — modern model extraction

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 **Most SQL linters use regex and only see raw `.sql` files. Valk Guard parses real source structure instead.**
 
-It reads Goqu builder chains, SQLAlchemy ORM calls, Go `db.Query` invocations, and C# EF Core `ExecuteSqlRaw` calls with source-aware scanners — Go and Python via AST, C# v1 via conservative text analysis of raw EF Core execution patterns. It synthesizes SQL from your ORM code, feeds it through a real PostgreSQL grammar, and runs every rule against it.
+It reads Goqu builder chains, SQLAlchemy ORM calls, Go `db.Query` invocations, and C# EF Core raw/query-builder calls with source-aware scanners — Go via `go/ast`, Python via `ast`, and C# via Roslyn. It synthesizes SQL from your ORM code, feeds it through a real PostgreSQL grammar, and runs every rule against it.
 
 That means: if your ORM builds a `DELETE` without a `WHERE`, Valk Guard catches it — even though no raw SQL exists anywhere in your source.
 
@@ -108,7 +108,7 @@ Valk Guard ships with **19 rules** across three categories. Here are the highlig
 
 ## Not Regex — Source-Aware Analysis
 
-Most SQL linters use regex. Valk Guard **walks real source structure** instead. It compiles and walks the actual AST of your Go and Python code, and for C# v1 it uses conservative text analysis of EF Core raw SQL execution calls. It understands ORM builder chains and raw execution APIs as first-class SQL sources — no `.sql` file required.
+Most SQL linters use regex. Valk Guard **walks real source structure** instead. It compiles and walks the actual AST of your Go and Python code, and for C# it invokes a Roslyn AST extractor for EF Core raw SQL and deterministic query-builder calls. It understands ORM builder chains and raw execution APIs as first-class SQL sources — no `.sql` file required.
 
 <table>
 <tr>
@@ -137,7 +137,7 @@ Most SQL linters use regex. Valk Guard **walks real source structure** instead. 
 </tr>
 </table>
 
-No raw SQL in those files. Valk Guard synthesizes SQL from the ORM calls, parses it with a PostgreSQL grammar, and runs all 19 rules against it (a handful of checks use targeted regex on parser-extracted clauses when the AST doesn't expose the needed field; Go/Python source scanning is AST-based, while C# v1 uses conservative text analysis for EF Core raw SQL execution).
+No raw SQL in those files. Valk Guard synthesizes SQL from the ORM calls, parses it with a PostgreSQL grammar, and runs all 19 rules against it (a handful of checks use targeted regex on parser-extracted clauses when the parser AST doesn't expose the needed field; Goqu, SQLAlchemy, and C# EF Core source scanning are AST-based).
 
 | Source | How it works |
 |--------|-------------|
@@ -145,11 +145,11 @@ No raw SQL in those files. Valk Guard synthesizes SQL from the ORM calls, parses
 | **Go** (`go/ast`) | Extracts SQL from `db.Query`, `db.Exec`, `db.QueryRow` and context variants |
 | **Goqu** | Walks builder chains (`From`/`Join`/`Where`/`Limit`/`ForUpdate`) via Go AST |
 | **SQLAlchemy** | Parses ORM chains (`query`/`select`/`join`/`filter`) via Python AST |
-| **C# (EF Core)** | Extracts SQL from `ExecuteSqlRaw`, `ExecuteSqlInterpolated` and async variants via conservative text analysis |
+| **C# (EF Core)** | Extracts SQL from `ExecuteSql*`, `FromSql*`, `SqlQuery*`, and synthesizes SQL from deterministic DbSet/LINQ chains |
 
 For schema-drift rules (VG101+), it also reads **ORM model definitions** — Go struct tags (`db`, `gorm`) and Python `__tablename__` / `Column(...)` — and cross-references them against your migration DDL.
 
-> **C# note:** v1 covers raw EF Core SQL execution only (`ExecuteSqlRaw`, `ExecuteSqlInterpolated`, and async variants). Query-builder and LINQ patterns are tracked separately.
+> **C# note:** query-builder synthesis is intentionally conservative. It covers deterministic DbSet/LINQ shapes such as `Where`, `Select`, `Take`, `Include`, `Join`, `ExecuteDelete`, and `ExecuteUpdate`; uncertain dynamic expressions are skipped.
 
 ---
 
@@ -290,8 +290,8 @@ make install
 ### Requirements
 
 - **Go >= 1.25.8** for building from source
-- **Python >= 3.6** only when scanning `.py` files for SQLAlchemy usage. No pip packages needed — Valk Guard ships an embedded script using only stdlib (`ast`, `json`). If scanned `.py` files are present and `python3` is missing or too old, the scan fails fast with an error.
-- **No external runtime** for C# scanning — the EF Core scanner is a pure Go text-based analyzer, no .NET SDK required.
+- **Python >= 3.6** only when scanning `.py` files for SQLAlchemy usage. No pip packages needed — Valk Guard ships an embedded script using only stdlib (`ast`, `json`). If SQLAlchemy candidate files are present and `python3` is missing or too old, the scan fails fast with an error.
+- **.NET SDK >= 8.0** only when scanning C# files containing EF Core markers. The scanner uses an embedded Roslyn extractor and is not invoked for projects without C# EF Core candidates. Disable it with `sources.csharp: false` if needed.
 
 ---
 
@@ -311,6 +311,15 @@ migration_paths:
   - "db/migrations"
   - "schema/**/*.sql"
 
+# Optional: disable whole source scanners/model extractors.
+# Missing entries default to true.
+sources:
+  sql: true
+  go: true       # database/sql-style Go scanning
+  goqu: true
+  sqlalchemy: true # aliases: python, py
+  csharp: true     # aliases: cs, c#, dotnet
+
 rules:
   VG001:
     severity: warning
@@ -323,6 +332,7 @@ go_model:
 ```
 
 Reference: [`.valk-guard.yaml.example`](.valk-guard.yaml.example)
+Source config details: [`docs/source-config.md`](docs/source-config.md)
 
 ### Inline Suppression
 
@@ -359,8 +369,8 @@ flowchart LR
     B1["Raw SQL Scanner"]
     B2["Go AST Scanner"]
     B3["Goqu Scanner"]
-    B4["SQLAlchemy Scanner"]
-    B6["C# EF Core Scanner"]
+    B4["SQLAlchemy Python AST Scanner"]
+    B6["C# EF Core Roslyn AST Scanner"]
     B5["Statements with file/line mapping"]
   end
 
@@ -419,9 +429,8 @@ flowchart LR
 
 Track progress and vote on what matters to you:
 
-- C# EF Core query-builder support — `FromSqlRaw`, `SqlQueryRaw`, LINQ patterns
-- GORM scanner — AST-based scanning for GORM builder chains and model extraction
 - Deeper builder semantics — aliases, nested subqueries, richer predicate trees
+- More ORM integrations with AST-backed synthetic SQL
 - SQLAlchemy 2.0 `mapped_column()` support — modern model extraction
 - Custom rule authoring — define your own rules in YAML or Go
 - Severity-gated CI — block PRs only on errors, not warnings
@@ -432,6 +441,7 @@ Track progress and vote on what matters to you:
 
 - [All 19 rules — full reference](docs/rules.md)
 - [Schema-drift detection](docs/schema-drift.md)
+- [Source configuration](docs/source-config.md)
 - [Suppression and noise control](docs/suppression.md)
 - [Output formats (terminal, JSON, rdjsonl, SARIF)](docs/output-formats.md)
 - [CI reviewer mode](docs/ci-reviewer-mode.md)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ No raw SQL in those files. Valk Guard synthesizes SQL from the ORM calls, parses
 
 For schema-drift rules (VG101+), it also reads **ORM model definitions** — Go struct tags (`db`, `gorm`) and Python `__tablename__` / `Column(...)` — and cross-references them against your migration DDL.
 
-> **C# note:** query-builder synthesis is intentionally conservative. It covers deterministic DbSet/LINQ shapes such as `Where`, `Select`, `Take`, `Include`, `Join`, `ExecuteDelete`, and `ExecuteUpdate`; uncertain dynamic expressions are skipped.
+> **C# note:** query-builder synthesis is intentionally conservative. It covers deterministic DbSet/LINQ shapes such as Where, Select, Take, Skip, Include, Join, GroupJoin, SelectMany, OrderBy, GroupBy, Having, Distinct, ExecuteDelete, ExecuteUpdate, Count, Any, All, Sum, Min, Max, Average, IN/NOT IN via Contains, LIKE/ILIKE, and raw FOR UPDATE via FromSql/ExecuteSql; uncertain dynamic expressions are skipped. `ExecuteSqlRaw` format normalization rewrites `{0}` placeholders to `$1`, so literal `{0}` text inside raw SQL is a known caveat.
 
 ---
 
@@ -291,7 +291,7 @@ make install
 
 - **Go >= 1.25.8** for building from source
 - **Python >= 3.6** only when scanning `.py` files for SQLAlchemy usage. No pip packages needed — Valk Guard ships an embedded script using only stdlib (`ast`, `json`). If SQLAlchemy candidate files are present and `python3` is missing or too old, the scan fails fast with an error.
-- **.NET SDK >= 8.0** only when scanning `.cs` files. The scanner sends C# files to an embedded Roslyn extractor so candidate detection is syntax-based instead of substring-based. Disable it with `sources.csharp: false` if needed.
+- **.NET SDK >= 8.0** only when scanning `.cs` files. The scanner sends C# files to an embedded Roslyn extractor so candidate detection is syntax-based instead of substring-based. The embedded extractor is materialized under the user cache directory, published once as a self-contained binary for the current OS/architecture, and reused until its bundled source changes. Disable it with `sources.csharp: false` if needed.
 
 ---
 

--- a/cmd/valk-guard/main.go
+++ b/cmd/valk-guard/main.go
@@ -80,7 +80,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "valk-guard",
 		Short:         "Static SQL performance linter for CI/CD",
-		Long:          "Valk Guard scans SQL across SQL, Go, Goqu, and SQLAlchemy sources and reports performance, safety, and schema-aware findings.",
+		Long:          "Valk Guard scans SQL across SQL, Go, Goqu, SQLAlchemy, and C# (EF Core) sources and reports performance, safety, and schema-aware findings.",
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Version:       version,
@@ -182,7 +182,7 @@ func runScan(opts scanOptions, args []string, stdout, stderr io.Writer) (int, er
 		return exitError, err
 	}
 	if !result.HadScannableInputs {
-		logger.Warn("no .sql, .go, or .py files found in scan paths")
+		logger.Warn("no .sql, .go, .py, or .cs files found in scan paths")
 	}
 
 	out := stdout

--- a/cmd/valk-guard/main_test.go
+++ b/cmd/valk-guard/main_test.go
@@ -91,7 +91,7 @@ func TestRunScanNoScannableFilesFeedback(t *testing.T) {
 	if !strings.Contains(stdout.String(), "(no scannable files found)") {
 		t.Fatalf("expected no scannable files message, got %q", stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "no .sql, .go, or .py files found in scan paths") {
+	if !strings.Contains(stderr.String(), "no .sql, .go, .py, or .cs files found in scan paths") {
 		t.Fatalf("expected warning about missing scannable files, got %q", stderr.String())
 	}
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 - [All 19 rules — full reference](rules.md)
 - [Schema-drift detection](schema-drift.md)
+- [Source configuration](source-config.md)
 - [Suppression and noise control](suppression.md)
 - [Output formats (terminal, JSON, rdjsonl, SARIF)](output-formats.md)
 - [CI reviewer mode](ci-reviewer-mode.md)

--- a/docs/adding-sources.md
+++ b/docs/adding-sources.md
@@ -73,7 +73,7 @@ Examples:
 
 - `internal/scanner/goqu/goqu_scanner.go` (Go AST-based)
 - `internal/scanner/sqlalchemy/sqlalchemy_scanner.go` (Python subprocess)
-- `internal/scanner/csharp/scanner.go` (Go wrapper around an embedded Roslyn AST extractor; raw EF Core APIs plus synthetic SQL for deterministic DbSet/LINQ chains)
+- `internal/scanner/csharp/scanner.go` (Go wrapper around a cached embedded Roslyn AST extractor; raw EF Core APIs plus synthetic SQL for deterministic DbSet/LINQ chains)
 
 ### 3) Register Scanner Binding
 
@@ -89,11 +89,32 @@ Add an entry in `defaultScannerBindings()`:
 
 File discovery is automatic from registered extensions via `requiredExtensions(...)` and `collectScannerInputs(...)`. Top-level `sources.<engine>: false` config filters the binding before discovery, so disabled sources do not collect files or invoke external runtimes.
 
+The C# wrapper materializes the embedded Roslyn extractor under `os.UserCacheDir()/valk-guard/roslynextractor-<contenthash>`, publishes it once as a self-contained binary for the current OS/architecture, and then executes that binary directly until the embedded extractor source changes. This trades cache size for scan-time startup cost: the published binary is intentionally not committed to the repository, is about 80 MB on linux-x64 with Roslyn included, and lets repeated scans avoid `dotnet run`, restore, and build work.
+
 Synthetic SQL conventions:
 
 - Prefix generated statements with `/* valk-guard:synthetic <source> */` so output makes the origin explicit.
 - Render non-literal bind values as PostgreSQL-style numbered placeholders (`$1`, `$2`, ...), resetting numbering per emitted statement.
 - Prefer structurally valid SQL over perfect fidelity; the parser must accept the statement and the rule engine must see the relevant clauses.
+
+
+Parity checklist for ORM/query-builder scanners:
+
+| Feature | Expected synthetic shape |
+| --- | --- |
+| Select star | `SELECT * FROM table` |
+| Missing write filter | `UPDATE table SET col = $1` / `DELETE FROM table` without `WHERE` |
+| Unbounded select | `SELECT cols FROM table` without `LIMIT` |
+| LIKE / ILIKE | `col LIKE pattern` / `col ILIKE pattern` |
+| IN / NOT IN | `col IN ($1, $2, $3)` / `col NOT IN ($1, $2, $3)` |
+| Order / offset | `ORDER BY col ASC|DESC ... OFFSET n` |
+| Group / having | `GROUP BY col HAVING predicate` |
+| Distinct | `SELECT DISTINCT ...` |
+| Aggregates | `SUM(col)`, `MIN(col)`, `MAX(col)`, `AVG(col)`, `COUNT(*)` |
+| Joins | Preserve join type and emit real `ON a = b` when the AST exposes it; otherwise use `ON 1=1` |
+| Row locks | Preserve raw `FOR UPDATE`; only synthesize ORM lock methods that exist in the source framework |
+
+Known caveat: raw SQL format-string normalization rewrites `{{0}}`, `{{1}}`, ... to `$1`, `$2`, ... for parser/rule consistency. Literal brace placeholders in raw SQL text may be rewritten.
 
 ### 4) Optional: Add Model Extractor
 

--- a/docs/adding-sources.md
+++ b/docs/adding-sources.md
@@ -71,8 +71,9 @@ Create `internal/scanner/<source>/...` implementing `Scan(...)`.
 
 Examples:
 
-- `internal/scanner/goqu/goqu_scanner.go`
-- `internal/scanner/sqlalchemy/sqlalchemy_scanner.go`
+- `internal/scanner/goqu/goqu_scanner.go` (Go AST-based)
+- `internal/scanner/sqlalchemy/sqlalchemy_scanner.go` (Python subprocess)
+- `internal/scanner/csharp/scanner.go` (text analysis, no external runtime)
 
 ### 3) Register Scanner Binding
 

--- a/docs/adding-sources.md
+++ b/docs/adding-sources.md
@@ -1,6 +1,6 @@
 # Adding Sources (Scanners + Models)
 
-This guide shows how to add a new source framework (for example GORM) so Valk Guard can lint its SQL and, when available, use model metadata for schema-aware rules.
+This guide shows how to add a new source framework (for example Ent or Dapper) so Valk Guard can lint its SQL and, when available, use model metadata for schema-aware rules.
 
 ## Source Architecture
 
@@ -60,7 +60,7 @@ Provenance contract:
 Add a new engine in `internal/scanner/scanner.go`, for example:
 
 ```go
-const EngineGorm Engine = "gorm"
+const EngineEnt Engine = "ent"
 ```
 
 Then add it to built-in engine allowlist in `internal/scanner/engines.go` (`knownEngines`), so config engine validation accepts it.
@@ -73,7 +73,7 @@ Examples:
 
 - `internal/scanner/goqu/goqu_scanner.go` (Go AST-based)
 - `internal/scanner/sqlalchemy/sqlalchemy_scanner.go` (Python subprocess)
-- `internal/scanner/csharp/scanner.go` (text analysis, no external runtime)
+- `internal/scanner/csharp/scanner.go` (Go wrapper around an embedded Roslyn AST extractor; raw EF Core APIs plus synthetic SQL for deterministic DbSet/LINQ chains)
 
 ### 3) Register Scanner Binding
 
@@ -81,13 +81,13 @@ Add an entry in `defaultScannerBindings()`:
 
 ```go
 {
-    name: "gorm",
-    impl: &gormscanner.Scanner{},
+    name: "ent",
+    impl: &entscanner.Scanner{},
     extensions: []string{".go"},
 }
 ```
 
-File discovery is automatic from registered extensions via `requiredExtensions(...)` and `collectScannerInputs(...)`.
+File discovery is automatic from registered extensions via `requiredExtensions(...)` and `collectScannerInputs(...)`. Top-level `sources.<engine>: false` config filters the binding before discovery, so disabled sources do not collect files or invoke external runtimes.
 
 ### 4) Optional: Add Model Extractor
 
@@ -113,11 +113,11 @@ Add an entry in `defaultModelBindings()`:
 
 ```go
 {
-    source:        schema.ModelSourceGorm,
-    extractor:     &gormmodel.Extractor{},
+    source:        schema.ModelSourceEnt,
+    extractor:     &entmodel.Extractor{},
     extensions:    []string{".go"},
-    configEngines: []scanner.Engine{scanner.EngineGorm},
-    queryEngines:  []scanner.Engine{scanner.EngineGorm},
+    configEngines: []scanner.Engine{scanner.EngineEnt},
+    queryEngines:  []scanner.Engine{scanner.EngineEnt},
 }
 ```
 
@@ -156,4 +156,5 @@ Binding fields control behavior:
 4. Optional extractor implemented and model-bound.
 5. Tests added for scanner/query-schema/schema-drift behavior.
 6. Docs updated.
-7. `go test ./...` passes.
+7. Source-level config docs updated if the source can be disabled.
+8. `go test ./...` passes.

--- a/docs/adding-sources.md
+++ b/docs/adding-sources.md
@@ -89,6 +89,12 @@ Add an entry in `defaultScannerBindings()`:
 
 File discovery is automatic from registered extensions via `requiredExtensions(...)` and `collectScannerInputs(...)`. Top-level `sources.<engine>: false` config filters the binding before discovery, so disabled sources do not collect files or invoke external runtimes.
 
+Synthetic SQL conventions:
+
+- Prefix generated statements with `/* valk-guard:synthetic <source> */` so output makes the origin explicit.
+- Render non-literal bind values as PostgreSQL-style numbered placeholders (`$1`, `$2`, ...), resetting numbering per emitted statement.
+- Prefer structurally valid SQL over perfect fidelity; the parser must accept the statement and the rule engine must see the relevant clauses.
+
 ### 4) Optional: Add Model Extractor
 
 If the source has model metadata, add `internal/schema/<source>/...` implementing `schema.ModelExtractor`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ graph TD
 | **Go Standard** | `go/ast` | Extracts SQL literals from `db.Query`, `db.Exec`, `sqlx`, etc. |
 | **Goqu** | Synthesis | Analyzes Goqu method chains to generate synthetic SQL for analysis. |
 | **SQLAlchemy** | Python AST | Invokes a Python sub-process to extract SQL from `text()` and ORM chains. |
-| **C# (EF Core)** | Roslyn AST | Invokes an embedded Roslyn extractor only for C# EF Core candidates; extracts `ExecuteSql*`, `FromSql*`, and `SqlQuery*`; synthesizes SQL from deterministic DbSet/LINQ chains (`Where`, `Select`, `Take`, `Include`, `Join`, `ExecuteDelete`, `ExecuteUpdate`). |
+| **C# (EF Core)** | Roslyn AST | Invokes a cached embedded Roslyn extractor for scanned `.cs` files; the extractor is published once as a self-contained binary per content hash; Roslyn decides from syntax whether to extract `ExecuteSql*`, `FromSql*`, and `SqlQuery*`; synthesizes SQL from deterministic DbSet/LINQ chains (Where, Select, Take, Skip, Include, Join, GroupJoin, SelectMany, OrderBy, GroupBy, Having, Distinct, ExecuteDelete, ExecuteUpdate, Count, Any, All, Sum, Min, Max, Average, IN/NOT IN via Contains, LIKE/ILIKE, and raw FOR UPDATE via FromSql/ExecuteSql). |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,12 +27,12 @@ graph TD
         B -->|.sql| C[Raw SQL Scanner]
         B -->|.go| D[Go AST Scanner]
         B -->|.go| E[Goqu Synth Scanner]
-        B -->|.py| F[SQLAlchemy Scanner]
-        B -->|.cs| G[C# EF Core Scanner]
+        B -->|.py| F[SQLAlchemy Python AST Scanner]
+        B -->|.cs| G[C# EF Core Roslyn Scanner]
     end
 
     subgraph "2. Analysis Engine"
-        C & D & E & F & G -->|SQL Stream| H[Valk PG Parser]
+        C & D & E & F & G -->|Raw + Synthetic SQL Stream| H[Valk PG Parser]
         H -->|AST| I[Rule Engine]
         I -->|Findings| J[Deduplicator]
     end
@@ -56,7 +56,7 @@ graph TD
 | **Go Standard** | `go/ast` | Extracts SQL literals from `db.Query`, `db.Exec`, `sqlx`, etc. |
 | **Goqu** | Synthesis | Analyzes Goqu method chains to generate synthetic SQL for analysis. |
 | **SQLAlchemy** | Python AST | Invokes a Python sub-process to extract SQL from `text()` and ORM chains. |
-| **C# (EF Core)** | Text Analysis | Extracts SQL from `ExecuteSqlRaw`, `ExecuteSqlInterpolated`, and async variants. v1: raw SQL execution only. |
+| **C# (EF Core)** | Roslyn AST | Invokes an embedded Roslyn extractor only for C# EF Core candidates; extracts `ExecuteSql*`, `FromSql*`, and `SqlQuery*`; synthesizes SQL from deterministic DbSet/LINQ chains (`Where`, `Select`, `Take`, `Include`, `Join`, `ExecuteDelete`, `ExecuteUpdate`). |
 
 ---
 
@@ -134,6 +134,10 @@ Control Valk Guard via a `.valk-guard.yaml` file:
 exclude:
   - "vendor/**"
   - "db/migrations/*.gen.sql"
+
+sources:
+  sqlalchemy: true  # aliases: python, py
+  csharp: false     # aliases: cs, c#, dotnet
 
 rules:
   VG001:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@
 
 ## What It Does
 
-Valk Guard acts as a static gatekeeper for your database. It scans your codebase (Go, Python, SQL), extracts database interactions, parses them using a formal PostgreSQL grammar, and runs them against a suite of performance-focused rules.
+Valk Guard acts as a static gatekeeper for your database. It scans your codebase (Go, Python, SQL, C#), extracts database interactions, parses them using a formal PostgreSQL grammar, and runs them against a suite of performance-focused rules.
 
 ### Core Value Proposition
 - **Prevent Outages**: Catch `UPDATE` or `DELETE` statements missing a `WHERE` clause.
@@ -28,20 +28,21 @@ graph TD
         B -->|.go| D[Go AST Scanner]
         B -->|.go| E[Goqu Synth Scanner]
         B -->|.py| F[SQLAlchemy Scanner]
+        B -->|.cs| G[C# EF Core Scanner]
     end
 
     subgraph "2. Analysis Engine"
-        C & D & E & F -->|SQL Stream| G[Valk PG Parser]
-        G -->|AST| H[Rule Engine]
-        H -->|Findings| I[Deduplicator]
+        C & D & E & F & G -->|SQL Stream| H[Valk PG Parser]
+        H -->|AST| I[Rule Engine]
+        I -->|Findings| J[Deduplicator]
     end
 
     subgraph "3. Reporting"
-        I --> J{Output Format}
-        J -->|Terminal| K[Human Readable]
-        J -->|JSON| L[Machine Readable]
-        J -->|SARIF| M[GitHub Code Scanning]
-        J -->|rdjsonl| N[reviewdog PR Review]
+        J --> K{Output Format}
+        K -->|Terminal| L[Human Readable]
+        K -->|JSON| M[Machine Readable]
+        K -->|SARIF| N[GitHub Code Scanning]
+        K -->|rdjsonl| O[reviewdog PR Review]
     end
 ```
 
@@ -55,6 +56,7 @@ graph TD
 | **Go Standard** | `go/ast` | Extracts SQL literals from `db.Query`, `db.Exec`, `sqlx`, etc. |
 | **Goqu** | Synthesis | Analyzes Goqu method chains to generate synthetic SQL for analysis. |
 | **SQLAlchemy** | Python AST | Invokes a Python sub-process to extract SQL from `text()` and ORM chains. |
+| **C# (EF Core)** | Text Analysis | Extracts SQL from `ExecuteSqlRaw`, `ExecuteSqlInterpolated`, and async variants. v1: raw SQL execution only. |
 
 ---
 
@@ -146,3 +148,4 @@ You can disable rules for specific lines using comments:
 - **SQL**: `-- valk-guard:disable VG001`
 - **Go**: `// valk-guard:disable VG001`
 - **Python**: `# valk-guard:disable VG001`
+- **C#**: `// valk-guard:disable VG001`

--- a/docs/architecture.mermaid
+++ b/docs/architecture.mermaid
@@ -2,13 +2,21 @@ graph TD
     subgraph "CLI"
         CLI_CMD[valk-guard scan] --> CFG[Load Config]
         CFG --> BIND[Load Source Bindings]
+        CFG --> SRCFILTER[Apply sources enablement]
+        BIND --> SRCFILTER
     end
 
     subgraph "Discovery and Extraction"
-        BIND --> DISCOVER[Discover Files by Bound Extensions]
-        DISCOVER --> SCANNERS[Run Bound Scanners]
-        DISCOVER --> EXTRACTORS[Run Bound Model Extractors]
-        SCANNERS --> STMTS[SQLStatement Stream]
+        SRCFILTER --> DISCOVER[Discover Files by Enabled Extensions]
+        DISCOVER --> SCANNERS[Run Enabled Scanners]
+        DISCOVER --> EXTRACTORS[Run Enabled Model Extractors]
+        SCANNERS --> RAW[Raw SQL extraction]
+        SCANNERS --> SYNTH[Synthetic SQL generation]
+        SCANNERS --> ROSLYN[C# Roslyn AST extractor when EF Core .cs candidates exist]
+        ROSLYN --> RAW
+        ROSLYN --> SYNTH
+        RAW --> STMTS[SQLStatement Stream]
+        SYNTH --> STMTS
         STMTS --> META[Attach file line engine and disable directives]
     end
 
@@ -43,4 +51,5 @@ graph TD
         REPORT --> TERM[Terminal]
         REPORT --> JSON[JSON]
         REPORT --> SARIF[SARIF 2 1 0]
+        REPORT --> RDJSONL[rdjsonl]
     end

--- a/docs/ci-example-changed-files.md
+++ b/docs/ci-example-changed-files.md
@@ -1,6 +1,6 @@
 ## CI Example: Changed-Files-Only PR Scan
 
-Copy-paste this when you want PR scans to look only at changed `.sql`, `.go`, and `.py` files.
+Copy-paste this when you want PR scans to look only at changed `.sql`, `.go`, `.py`, and `.cs` files.
 
 Use it when:
 
@@ -47,6 +47,7 @@ jobs:
             **/*.sql
             **/*.go
             **/*.py
+            **/*.cs
 
       - uses: reviewdog/action-setup@v1
         if: steps.changed.outputs.any_changed == 'true'

--- a/docs/ci-reviewer-mode.md
+++ b/docs/ci-reviewer-mode.md
@@ -91,6 +91,7 @@ jobs:
             **/*.sql
             **/*.go
             **/*.py
+            **/*.cs
 
       - uses: reviewdog/action-setup@v1
         if: steps.changed.outputs.any_changed == 'true'
@@ -160,7 +161,7 @@ jq -cr '((if type == "array" then . else .findings end) // [])[]'
 ```
 ## Changed-Files-Only Pattern (Recommended for PRs)
 
-Run Valk Guard on PR-diff files (`.sql`, `.go`, `.py`) instead of full-repo scans to reduce noise and runtime.
+Run Valk Guard on PR-diff files (`.sql`, `.go`, `.py`, `.cs`) instead of full-repo scans to reduce noise and runtime.
 
 ## Resolution Model
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -8,6 +8,7 @@ This directory contains examples demonstrating how Valk Guard scans different la
 *   `go_std/`: Go code using the standard `database/sql` package.
 *   `go_goqu/`: Go code using the `goqu` query builder (AST analysis).
 *   `python_sqlalchemy/`: Python code using SQLAlchemy ORM/Core (AST analysis).
+*   C# EF Core scanning is covered by unit tests and the Roslyn AST extractor; examples can be added as a dedicated folder when docs ship C# snippets.
 *   `schema_drift/`: Go models + SQL migrations demonstrating schema-drift detection (VG101+).
 
 ## Running the Examples
@@ -35,16 +36,16 @@ The linter will flag deliberate anti-patterns included in these files (e.g., `SE
 
 Each example folder contains explicit labeled snippets for all built-in rules `VG001` through `VG008`.
 
-| Rule | `raw_sql` | `go_std` | `go_goqu` | `python_sqlalchemy` |
-| --- | --- | --- | --- | --- |
-| VG001 `select-star` | yes | yes | yes | yes |
-| VG002 `missing-where-update` | yes | yes | yes | yes |
-| VG003 `missing-where-delete` | yes | yes | yes | yes |
-| VG004 `unbounded-select` | yes | yes | yes | yes |
-| VG005 `like-leading-wildcard` | yes | yes | yes | yes |
-| VG006 `select-for-update-no-where` | yes | yes | yes (ORM chain) | yes (ORM chain) |
-| VG007 `destructive-ddl` | yes | yes | yes (raw `goqu.L`) | yes (raw `text(...)`) |
-| VG008 `non-concurrent-index` | yes | yes | yes (raw `goqu.L`) | yes (raw `text(...)`) |
+| Rule | `raw_sql` | `go_std` | `go_goqu` | `python_sqlalchemy` | C# EF Core tests |
+| --- | --- | --- | --- | --- | --- |
+| VG001 `select-star` | yes | yes | yes | yes | yes |
+| VG002 `missing-where-update` | yes | yes | yes | yes | yes |
+| VG003 `missing-where-delete` | yes | yes | yes | yes | yes |
+| VG004 `unbounded-select` | yes | yes | yes | yes | yes |
+| VG005 `like-leading-wildcard` | yes | yes | yes | yes | yes |
+| VG006 `select-for-update-no-where` | yes | yes | yes (ORM chain) | yes (ORM chain) | yes (raw EF SQL) |
+| VG007 `destructive-ddl` | yes | yes | yes (raw `goqu.L`) | yes (raw `text(...)`) | yes (raw EF SQL) |
+| VG008 `non-concurrent-index` | yes | yes | yes (raw `goqu.L`) | yes (raw `text(...)`) | yes (raw EF SQL) |
 
 The `schema_drift/` example demonstrates VG101 (dropped-column) by including a model field that references a column not present in migrations.
 

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -92,8 +92,10 @@ JSON object per line with:
   - a human-readable origin hint for synthetic builder-derived SQL
   - a compact query preview
 
-Synthetic scanner prefixes such as `/* valk-guard:synthetic sqlalchemy-ast */`
-are stripped automatically from the user-facing message.
+Synthetic scanner prefixes such as `/* valk-guard:synthetic goqu-ast */`,
+`/* valk-guard:synthetic sqlalchemy-ast */`, and
+`/* valk-guard:synthetic csharp-efcore */` are stripped automatically from the
+user-facing message.
 
 Example:
 

--- a/docs/schema-drift.md
+++ b/docs/schema-drift.md
@@ -141,12 +141,12 @@ Column types are extracted from `Column()` arguments for type-mismatch detection
 
 ## Query-Schema Support Matrix
 
-| Rule  | sql | go | goqu | sqlalchemy | Notes |
-|-------|-----|----|------|------------|-------|
-| VG105 | yes | yes | yes | yes | Validates projected columns (`SELECT a, b`) against migration schema; for `go/goqu` and `sqlalchemy`, also validates against model-derived columns when present. |
-| VG106 | yes | yes | yes | yes | Validates columns in `WHERE`, `JOIN ... ON ...` (including `INNER JOIN`), `GROUP BY`, and `ORDER BY` against migration schema; for `go/goqu` and `sqlalchemy`, also validates against model-derived columns when present. |
-| VG107 | yes | yes | yes | yes | Validates referenced tables in `FROM`/`JOIN` against schema sources. |
-| VG108 | yes | yes | yes | yes | Validates that unqualified columns are not ambiguous across joined tables. |
+| Rule  | sql | go | goqu | sqlalchemy | csharp | Notes |
+|-------|-----|----|------|------------|--------|-------|
+| VG105 | yes | yes | yes | yes | yes | Validates projected columns (`SELECT a, b`) against migration schema; for `go/goqu` and `sqlalchemy`, also validates against model-derived columns when present. |
+| VG106 | yes | yes | yes | yes | yes | Validates columns in `WHERE`, `JOIN ... ON ...` (including `INNER JOIN`), `GROUP BY`, and `ORDER BY` against migration schema; for `go/goqu` and `sqlalchemy`, also validates against model-derived columns when present. |
+| VG107 | yes | yes | yes | yes | yes | Validates referenced tables in `FROM`/`JOIN` against schema sources. |
+| VG108 | yes | yes | yes | yes | yes | Validates that unqualified columns are not ambiguous across joined tables. |
 
 ## Configuration
 
@@ -169,23 +169,23 @@ rules:
     engines: [sqlalchemy] # explicit table mappings only
   VG105:
     severity: error
-    engines: [goqu, sqlalchemy]
+    engines: [goqu, sqlalchemy, csharp]
   VG106:
     severity: error
-    engines: [goqu, sqlalchemy]
+    engines: [goqu, sqlalchemy, csharp]
   VG107:
     severity: error
-    engines: [goqu, sqlalchemy]
+    engines: [goqu, sqlalchemy, csharp]
   VG108:
     severity: warning
-    engines: [sql, go, goqu, sqlalchemy]
+    engines: [sql, go, goqu, sqlalchemy, csharp]
 ```
 
 Schema rules honor `engines` filtering by source:
 
 - `go` for Go `db` tag models
 - `sqlalchemy` for Python SQLAlchemy models
-- `sql`, `go`, `goqu`, `sqlalchemy` for query-schema rules (`VG105`-`VG108`)
+- `sql`, `go`, `goqu`, `sqlalchemy`, `csharp` for query-schema rules (`VG105`-`VG108`)
 
 ## Type Compatibility (VG103)
 

--- a/docs/source-config.md
+++ b/docs/source-config.md
@@ -1,0 +1,77 @@
+# Source Configuration
+
+Valk Guard enables every source scanner by default. Use top-level `sources` in
+`.valk-guard.yaml` to disable whole integrations before file discovery and
+external runtime startup.
+
+```yaml
+sources:
+  sql: true          # .sql files
+  go: true           # database/sql-style Go string scanning
+  goqu: true         # Goqu AST synthetic SQL
+  sqlalchemy: true   # Python SQLAlchemy AST synthetic SQL
+  csharp: true       # C# EF Core Roslyn synthetic SQL
+```
+
+Missing entries default to `true`, so this is enough to turn off C# while keeping
+everything else enabled:
+
+```yaml
+sources:
+  csharp: false
+```
+
+To turn off all Go source scanning, disable both Go integrations:
+
+```yaml
+sources:
+  go: false
+  goqu: false
+```
+
+`go` controls database/sql-style Go string scanning. `goqu` controls Goqu AST
+synthetic SQL. If either is enabled, `.go` files may still be discovered because
+that enabled source needs them.
+
+## Aliases
+
+The config accepts these aliases and normalizes them internally:
+
+| Alias | Source |
+| --- | --- |
+| `python`, `py` | `sqlalchemy` |
+| `cs`, `c#`, `dotnet` | `csharp` |
+
+Example:
+
+```yaml
+sources:
+  python: false
+  cs: false
+```
+
+## Difference From Rule Engine Filters
+
+`sources` disables scanner/model-extractor integrations entirely. Disabled
+sources do not collect files, do not invoke Python or .NET, and do not emit SQL
+statements.
+
+`rules.<id>.engines` only filters findings after SQL has already been scanned
+and parsed:
+
+```yaml
+rules:
+  VG001:
+    engines: [sql, goqu]
+```
+
+Use `sources` for runtime/control-plane behavior. Use `rules.<id>.engines` for
+rule noise tuning.
+
+## Runtime Notes
+
+- SQL, Go, and Goqu scanning run in the Valk Guard binary.
+- SQLAlchemy scanning invokes Python only when `.py` candidates contain
+  SQLAlchemy markers.
+- C# scanning invokes `dotnet` and the embedded Roslyn extractor only when `.cs`
+  candidates contain EF Core markers.

--- a/docs/source-config.md
+++ b/docs/source-config.md
@@ -73,5 +73,7 @@ rule noise tuning.
 - SQL, Go, and Goqu scanning run in the Valk Guard binary.
 - SQLAlchemy scanning invokes Python only when `.py` candidates contain
   SQLAlchemy markers.
-- C# scanning invokes `dotnet` and the embedded Roslyn extractor only when `.cs`
-  candidates contain EF Core markers.
+- C# scanning invokes `dotnet` and the embedded Roslyn extractor when `.cs`
+  files are scanned. Roslyn decides from parsed syntax whether EF Core SQL or
+  deterministic LINQ chains are present; the Go wrapper does not substring-match
+  C# code constructs.

--- a/docs/suppression.md
+++ b/docs/suppression.md
@@ -34,9 +34,9 @@ rules:
   VG001:
     enabled: true
     severity: warning
-    engines: [all] # all | sql | go | goqu | sqlalchemy
+    engines: [all] # all | sql | go | goqu | sqlalchemy | csharp
   VG005:
-    engines: [goqu, sqlalchemy]
+    engines: [goqu, sqlalchemy, csharp]
   VG007:
     enabled: false
 ```
@@ -85,16 +85,16 @@ rules:
     engines: [sqlalchemy] # explicit table mappings only
   VG105:
     severity: error
-    engines: [goqu, sqlalchemy]
+    engines: [goqu, sqlalchemy, csharp]
   VG106:
     severity: error
-    engines: [goqu, sqlalchemy]
+    engines: [goqu, sqlalchemy, csharp]
   VG107:
     severity: error
-    engines: [goqu, sqlalchemy]
+    engines: [goqu, sqlalchemy, csharp]
   VG108:
     severity: warning
-    engines: [sql, go, goqu, sqlalchemy]
+    engines: [sql, go, goqu, sqlalchemy, csharp]
   VG109:
     severity: warning
   VG110:
@@ -114,7 +114,7 @@ Schema-aware rules honor per-rule `engines` filtering:
 
 - `go` applies to models extracted from Go `db` tags.
 - `sqlalchemy` applies to models extracted from Python SQLAlchemy code.
-- `sql`, `go`, `goqu`, and `sqlalchemy` apply to query-schema statement sources.
+- `sql`, `go`, `goqu`, `sqlalchemy`, and `csharp` apply to query-schema statement sources.
 
 ## Goqu SELECT * Noise
 
@@ -125,7 +125,7 @@ To suppress VG001 for Goqu while keeping it active for other engines:
 ```yaml
 rules:
   VG001:
-    engines: [sql, go, sqlalchemy]  # exclude goqu
+    engines: [sql, go, sqlalchemy, csharp]  # exclude goqu
 ```
 
 ## Current Limitation

--- a/docs/suppression.md
+++ b/docs/suppression.md
@@ -41,7 +41,25 @@ rules:
     enabled: false
 ```
 
-## 3) Inline Suppression
+## 3) Source Scanner Tuning
+
+Use top-level `sources` to disable whole scanner/model-extractor integrations.
+Missing entries default to enabled.
+
+```yaml
+sources:
+  sql: true
+  go: true
+  goqu: true
+  sqlalchemy: false # aliases: python, py
+  csharp: false     # aliases: cs, c#, dotnet
+```
+
+This is different from `rules.<id>.engines`: `sources` prevents file discovery
+and external runtime invocation, while rule engine filters only control which
+findings can be emitted after a statement is scanned.
+
+## 4) Inline Suppression
 
 Use inline directives for one-off cases near the SQL source.
 
@@ -68,7 +86,7 @@ Python:
 session.execute(text("SELECT * FROM users"))
 ```
 
-## 4) Schema-Aware Rule Config
+## 5) Schema-Aware Rule Config
 
 Schema-aware rules (`VG101`-`VG111`) use the same per-rule config:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,13 +133,7 @@ func validateConfig(cfg *Config) error {
 		for source, enabled := range cfg.Sources {
 			candidate := normalizeSource(source)
 			if candidate == "" {
-				allowed := make([]string, 0, len(scanner.KnownEngines()))
-				for _, builtIn := range scanner.KnownEngines() {
-					allowed = append(allowed, string(builtIn))
-				}
-				allowed = append(allowed, "cs", "dotnet", "py", "python")
-				slices.Sort(allowed)
-				return fmt.Errorf("invalid source %q: must be one of %s", source, strings.Join(allowed, ", "))
+				return fmt.Errorf("invalid source %q: must be one of %s", source, strings.Join(acceptedEngineNames(), ", "))
 			}
 			if previous, exists := normalizedSources[candidate]; exists && previous != enabled {
 				return fmt.Errorf("conflicting source settings for %q", candidate)
@@ -163,13 +157,7 @@ func validateConfig(cfg *Config) error {
 			for _, engine := range rc.Engines {
 				candidate := normalizeEngine(engine)
 				if candidate != ruleEngineAll && !scanner.IsKnownEngineName(candidate) {
-					allowed := make([]string, 0, len(scanner.KnownEngines())+1)
-					allowed = append(allowed, ruleEngineAll)
-					for _, builtIn := range scanner.KnownEngines() {
-						allowed = append(allowed, string(builtIn))
-					}
-					slices.Sort(allowed)
-					return fmt.Errorf("invalid engine %q for rule %s: must be one of %s", engine, ruleID, strings.Join(allowed, ", "))
+					return fmt.Errorf("invalid engine %q for rule %s: must be one of %s", engine, ruleID, strings.Join(acceptedEngineNames(ruleEngineAll), ", "))
 				}
 				if _, exists := seen[candidate]; exists {
 					continue
@@ -190,27 +178,52 @@ func normalizeGoModelMappingMode(mode GoModelMappingMode) GoModelMappingMode {
 	return GoModelMappingMode(strings.ToLower(strings.TrimSpace(string(mode))))
 }
 
-// normalizeEngine trims whitespace and lowercases an engine string to produce
-// a canonical form suitable for comparison against known engine identifiers.
-func normalizeEngine(engine string) string {
-	return strings.ToLower(strings.TrimSpace(engine))
+var engineAliases = map[string]string{
+	"py":     string(scanner.EngineSQLAlchemy),
+	"python": string(scanner.EngineSQLAlchemy),
+	"cs":     string(scanner.EngineCSharp),
+	"c#":     string(scanner.EngineCSharp),
+	"dotnet": string(scanner.EngineCSharp),
 }
 
-// normalizeSource trims, lowercases, and maps user-friendly source aliases to
-// built-in engine identifiers used internally by scanner bindings.
-func normalizeSource(source string) string {
-	source = normalizeEngine(source)
-	switch source {
-	case "py", "python":
-		return string(scanner.EngineSQLAlchemy)
-	case "cs", "c#", "dotnet":
-		return string(scanner.EngineCSharp)
-	default:
-		if scanner.IsKnownEngineName(source) {
-			return source
-		}
-		return ""
+// normalizeAlias trims, lowercases, and maps user-friendly aliases to built-in
+// scanner engine identifiers. Unknown aliases return the normalized input.
+func normalizeAlias(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if canonical, ok := engineAliases[value]; ok {
+		return canonical
 	}
+	return value
+}
+
+// acceptedEngineNames returns known engines plus aliases for validation errors.
+func acceptedEngineNames(extra ...string) []string {
+	allowed := make([]string, 0, len(scanner.KnownEngines())+len(engineAliases)+len(extra))
+	allowed = append(allowed, extra...)
+	for _, builtIn := range scanner.KnownEngines() {
+		allowed = append(allowed, string(builtIn))
+	}
+	for alias := range engineAliases {
+		allowed = append(allowed, alias)
+	}
+	slices.Sort(allowed)
+	return slices.Compact(allowed)
+}
+
+// normalizeEngine trims whitespace, lowercases, and maps engine aliases to the
+// canonical engine name used by rule engine filters.
+func normalizeEngine(engine string) string {
+	return normalizeAlias(engine)
+}
+
+// normalizeSource trims whitespace, lowercases, and maps source aliases to the
+// canonical built-in engine identifier used by scanner bindings.
+func normalizeSource(source string) string {
+	source = normalizeAlias(source)
+	if scanner.IsKnownEngineName(source) {
+		return source
+	}
+	return ""
 }
 
 // normalizePathPatterns trims, canonicalizes, and de-duplicates path patterns.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,9 @@ type Config struct {
 	Exclude []string `yaml:"exclude,omitempty"`
 	// MigrationPaths restricts which .sql files build the schema snapshot.
 	MigrationPaths []string `yaml:"migration_paths,omitempty"`
+	// Sources enables or disables scanner/model sources by engine name. Missing
+	// entries default to enabled.
+	Sources map[string]bool `yaml:"sources,omitempty"`
 	// Rules holds per-rule enablement, severity, and engine overrides.
 	Rules map[string]RuleConfig `yaml:"rules,omitempty"`
 	// GoModel configures Go model extraction behavior.
@@ -125,6 +128,27 @@ func validateConfig(cfg *Config) error {
 		)
 	}
 
+	if len(cfg.Sources) > 0 {
+		normalizedSources := make(map[string]bool, len(cfg.Sources))
+		for source, enabled := range cfg.Sources {
+			candidate := normalizeSource(source)
+			if candidate == "" {
+				allowed := make([]string, 0, len(scanner.KnownEngines()))
+				for _, builtIn := range scanner.KnownEngines() {
+					allowed = append(allowed, string(builtIn))
+				}
+				allowed = append(allowed, "cs", "dotnet", "py", "python")
+				slices.Sort(allowed)
+				return fmt.Errorf("invalid source %q: must be one of %s", source, strings.Join(allowed, ", "))
+			}
+			if previous, exists := normalizedSources[candidate]; exists && previous != enabled {
+				return fmt.Errorf("conflicting source settings for %q", candidate)
+			}
+			normalizedSources[candidate] = enabled
+		}
+		cfg.Sources = normalizedSources
+	}
+
 	for ruleID, rc := range cfg.Rules {
 		if rc.Severity != "" &&
 			rc.Severity != rules.SeverityError &&
@@ -170,6 +194,23 @@ func normalizeGoModelMappingMode(mode GoModelMappingMode) GoModelMappingMode {
 // a canonical form suitable for comparison against known engine identifiers.
 func normalizeEngine(engine string) string {
 	return strings.ToLower(strings.TrimSpace(engine))
+}
+
+// normalizeSource trims, lowercases, and maps user-friendly source aliases to
+// built-in engine identifiers used internally by scanner bindings.
+func normalizeSource(source string) string {
+	source = normalizeEngine(source)
+	switch source {
+	case "py", "python":
+		return string(scanner.EngineSQLAlchemy)
+	case "cs", "c#", "dotnet":
+		return string(scanner.EngineCSharp)
+	default:
+		if scanner.IsKnownEngineName(source) {
+			return source
+		}
+		return ""
+	}
 }
 
 // normalizePathPatterns trims, canonicalizes, and de-duplicates path patterns.
@@ -235,6 +276,19 @@ func (c *Config) IsRuleEnabledForEngine(ruleID string, engine scanner.Engine) bo
 		}
 	}
 	return false
+}
+
+// IsSourceEnabled reports whether a scanner/model source is enabled. Sources
+// are enabled by default; configured false values opt a source out entirely.
+func (c *Config) IsSourceEnabled(engine scanner.Engine) bool {
+	if c == nil || len(c.Sources) == 0 {
+		return true
+	}
+	enabled, ok := c.Sources[string(engine)]
+	if !ok {
+		return true
+	}
+	return enabled
 }
 
 // ShouldExclude returns true if the given file path matches any exclude pattern.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/valkdb/valk-guard/internal/rules"
@@ -485,5 +486,64 @@ func TestIsRuleEnabledForEngine(t *testing.T) {
 	}
 	if !cfg.IsRuleEnabledForEngine("VG999", scanner.EngineSQL) {
 		t.Fatal("expected unknown rule to be enabled by default")
+	}
+}
+
+func TestSourceAliasMatrix(t *testing.T) {
+	aliases := map[string]string{
+		"csharp":     string(scanner.EngineCSharp),
+		"cs":         string(scanner.EngineCSharp),
+		"c#":         string(scanner.EngineCSharp),
+		"dotnet":     string(scanner.EngineCSharp),
+		"python":     string(scanner.EngineSQLAlchemy),
+		"py":         string(scanner.EngineSQLAlchemy),
+		"sqlalchemy": string(scanner.EngineSQLAlchemy),
+		"sql":        string(scanner.EngineSQL),
+		"go":         string(scanner.EngineGo),
+		"goqu":       string(scanner.EngineGoqu),
+	}
+
+	for alias, want := range aliases {
+		t.Run(alias, func(t *testing.T) {
+			cfg := Default()
+			cfg.Sources = map[string]bool{strings.ToUpper(alias): false}
+			if err := validateConfig(cfg); err != nil {
+				t.Fatalf("validateConfig() error = %v", err)
+			}
+			if _, ok := cfg.Sources[want]; !ok {
+				t.Fatalf("expected alias %q to normalize to %q, got %+v", alias, want, cfg.Sources)
+			}
+		})
+	}
+}
+
+func TestRuleEngineAliasesNormalize(t *testing.T) {
+	cfg := Default()
+	cfg.Rules["VG001"] = RuleConfig{Engines: []string{"python", "c#"}}
+	if err := validateConfig(cfg); err != nil {
+		t.Fatalf("validateConfig() error = %v", err)
+	}
+	if !cfg.IsRuleEnabledForEngine("VG001", scanner.EngineSQLAlchemy) {
+		t.Fatal("expected python alias to enable sqlalchemy")
+	}
+	if !cfg.IsRuleEnabledForEngine("VG001", scanner.EngineCSharp) {
+		t.Fatal("expected c# alias to enable csharp")
+	}
+	if cfg.IsRuleEnabledForEngine("VG001", scanner.EngineGoqu) {
+		t.Fatal("expected goqu to remain disabled")
+	}
+}
+
+func TestInvalidSourceErrorListsAliases(t *testing.T) {
+	cfg := Default()
+	cfg.Sources = map[string]bool{"oracle": true}
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected invalid source error")
+	}
+	for _, want := range []string{"c#", "cs", "dotnet", "py", "python", "sqlalchemy", "goqu"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to list alias %q, got %v", want, err)
+		}
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -379,6 +379,62 @@ func TestLoadInvalidRuleEngine(t *testing.T) {
 	}
 }
 
+func TestLoadInvalidSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad-source.yaml")
+	data := []byte("sources:\n  oracle: false\n")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid source, got nil")
+	}
+}
+
+func TestSourceEnablementDefaultsAndOverrides(t *testing.T) {
+	cfg := Default()
+	if !cfg.IsSourceEnabled(scanner.EngineCSharp) {
+		t.Fatal("expected csharp source enabled by default")
+	}
+
+	cfg.Sources = map[string]bool{
+		"cs":     false,
+		"Python": false,
+	}
+	if err := validateConfig(cfg); err != nil {
+		t.Fatalf("validateConfig() error = %v", err)
+	}
+	if cfg.IsSourceEnabled(scanner.EngineCSharp) {
+		t.Fatal("expected csharp source disabled")
+	}
+	if cfg.IsSourceEnabled(scanner.EngineSQLAlchemy) {
+		t.Fatal("expected sqlalchemy source disabled")
+	}
+	if !cfg.IsSourceEnabled(scanner.EngineGoqu) {
+		t.Fatal("expected unspecified goqu source to remain enabled")
+	}
+	if _, ok := cfg.Sources["Python"]; ok {
+		t.Fatal("expected source keys to be normalized")
+	}
+	if _, ok := cfg.Sources["python"]; ok {
+		t.Fatal("expected source alias to be normalized to sqlalchemy")
+	}
+}
+
+func TestConflictingSourceAliasesFailValidation(t *testing.T) {
+	cfg := Default()
+	cfg.Sources = map[string]bool{
+		"python":     false,
+		"sqlalchemy": true,
+	}
+
+	if err := validateConfig(cfg); err == nil {
+		t.Fatal("expected conflicting source alias validation error")
+	}
+}
+
 func TestLoadInvalidGoModelMappingMode(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bad-go-model-mode.yaml")

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -128,8 +128,8 @@ func Run(ctx context.Context, paths []string, cfg *config.Config, logger *slog.L
 // statement, applies enabled rules, and returns the deduplicated, sorted
 // findings.
 func collectAndAnalyze(ctx context.Context, paths []string, cfg *config.Config, reg *rules.Registry, logger *slog.Logger) ([]rules.Finding, bool, error) {
-	scannerBindings := defaultScannerBindings()
-	modelBindings := defaultModelBindings(cfg)
+	scannerBindings := filterScannerBindings(cfg, defaultScannerBindings())
+	modelBindings := filterModelBindings(cfg, defaultModelBindings(cfg))
 
 	inputs, err := collectScannerInputs(ctx, paths, cfg, requiredExtensions(scannerBindings, modelBindings))
 	if err != nil {

--- a/internal/engine/source_bindings.go
+++ b/internal/engine/source_bindings.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/valkdb/valk-guard/internal/config"
 	"github.com/valkdb/valk-guard/internal/scanner"
+	"github.com/valkdb/valk-guard/internal/scanner/csharp"
 	"github.com/valkdb/valk-guard/internal/scanner/goqu"
 	"github.com/valkdb/valk-guard/internal/scanner/sqlalchemy"
 	"github.com/valkdb/valk-guard/internal/schema"
@@ -92,6 +93,7 @@ func defaultScannerBindings() []scannerBinding {
 		{name: "go", impl: &scanner.GoScanner{}, extensions: []string{".go"}},
 		{name: "goqu", impl: &goqu.Scanner{}, extensions: []string{".go"}},
 		{name: "sqlalchemy", impl: &sqlalchemy.Scanner{}, extensions: []string{".py"}},
+		{name: "csharp", impl: &csharp.Scanner{}, extensions: []string{".cs"}},
 	}
 }
 

--- a/internal/engine/source_bindings.go
+++ b/internal/engine/source_bindings.go
@@ -118,6 +118,47 @@ func defaultModelBindings(cfg *config.Config) []modelBinding {
 	}
 }
 
+// filterScannerBindings removes scanners disabled by the top-level sources
+// config before file discovery decides which extensions are needed.
+func filterScannerBindings(cfg *config.Config, bindings []scannerBinding) []scannerBinding {
+	filtered := make([]scannerBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		if !cfg.IsSourceEnabled(scanner.Engine(binding.name)) {
+			continue
+		}
+		filtered = append(filtered, binding)
+	}
+	return filtered
+}
+
+// filterModelBindings removes model extractors whose related query/config
+// engines are all disabled by the top-level sources config.
+func filterModelBindings(cfg *config.Config, bindings []modelBinding) []modelBinding {
+	filtered := make([]modelBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		if modelBindingEnabled(cfg, binding) {
+			filtered = append(filtered, binding)
+		}
+	}
+	return filtered
+}
+
+// modelBindingEnabled reports whether any engine that can use a model binding
+// is enabled in source config.
+func modelBindingEnabled(cfg *config.Config, binding modelBinding) bool {
+	for _, engine := range binding.configEngines {
+		if cfg.IsSourceEnabled(engine) {
+			return true
+		}
+	}
+	for _, engine := range binding.queryEngines {
+		if cfg.IsSourceEnabled(engine) {
+			return true
+		}
+	}
+	return false
+}
+
 // requiredExtensions returns the set of file extensions needed for all active
 // scanners and model extractors.
 func requiredExtensions(scannerBindings []scannerBinding, modelBindings []modelBinding) []string {

--- a/internal/engine/source_bindings.go
+++ b/internal/engine/source_bindings.go
@@ -136,7 +136,7 @@ func filterScannerBindings(cfg *config.Config, bindings []scannerBinding) []scan
 func filterModelBindings(cfg *config.Config, bindings []modelBinding) []modelBinding {
 	filtered := make([]modelBinding, 0, len(bindings))
 	for _, binding := range bindings {
-		if modelBindingEnabled(cfg, binding) {
+		if modelBindingEnabled(cfg, &binding) {
 			filtered = append(filtered, binding)
 		}
 	}
@@ -145,7 +145,7 @@ func filterModelBindings(cfg *config.Config, bindings []modelBinding) []modelBin
 
 // modelBindingEnabled reports whether any engine that can use a model binding
 // is enabled in source config.
-func modelBindingEnabled(cfg *config.Config, binding modelBinding) bool {
+func modelBindingEnabled(cfg *config.Config, binding *modelBinding) bool {
 	for _, engine := range binding.configEngines {
 		if cfg.IsSourceEnabled(engine) {
 			return true

--- a/internal/engine/source_bindings_test.go
+++ b/internal/engine/source_bindings_test.go
@@ -1,0 +1,41 @@
+// Copyright 2025 ValkDB
+// SPDX-License-Identifier: Apache-2.0
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/valkdb/valk-guard/internal/config"
+	"github.com/valkdb/valk-guard/internal/scanner"
+)
+
+// TestSourceConfigFiltersScanners verifies top-level source config controls
+// which scanners participate in file discovery and execution.
+func TestSourceConfigFiltersScanners(t *testing.T) {
+	cfg := config.Default()
+	cfg.Sources = map[string]bool{"csharp": false, "sqlalchemy": false}
+
+	bindings := filterScannerBindings(cfg, defaultScannerBindings())
+	for _, binding := range bindings {
+		if binding.name == string(scanner.EngineCSharp) || binding.name == string(scanner.EngineSQLAlchemy) {
+			t.Fatalf("expected %s scanner to be filtered", binding.name)
+		}
+	}
+}
+
+// TestSourceConfigFiltersModelExtractors verifies disabling all related source
+// engines removes the matching model extractor from schema-aware analysis.
+func TestSourceConfigFiltersModelExtractors(t *testing.T) {
+	cfg := config.Default()
+	cfg.Sources = map[string]bool{"sqlalchemy": false}
+
+	bindings := filterModelBindings(cfg, defaultModelBindings(cfg))
+	for _, binding := range bindings {
+		for _, engine := range binding.queryEngines {
+			if engine == scanner.EngineSQLAlchemy {
+				t.Fatal("expected sqlalchemy model extractor to be filtered")
+			}
+		}
+	}
+}

--- a/internal/engine/source_bindings_test.go
+++ b/internal/engine/source_bindings_test.go
@@ -4,10 +4,12 @@
 package engine
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/valkdb/valk-guard/internal/config"
 	"github.com/valkdb/valk-guard/internal/scanner"
+	"github.com/valkdb/valk-guard/internal/schema"
 )
 
 // TestSourceConfigFiltersScanners verifies top-level source config controls
@@ -37,5 +39,60 @@ func TestSourceConfigFiltersModelExtractors(t *testing.T) {
 				t.Fatal("expected sqlalchemy model extractor to be filtered")
 			}
 		}
+	}
+}
+
+func TestSourceBindingHelpers(t *testing.T) {
+	cfg := config.Default()
+	scanners := filterScannerBindings(cfg, defaultScannerBindings())
+	models := filterModelBindings(cfg, defaultModelBindings(cfg))
+
+	exts := requiredExtensions(scanners, models)
+	for _, want := range []string{".cs", ".go", ".py", ".sql"} {
+		if !slices.Contains(exts, want) {
+			t.Fatalf("expected required extension %q in %v", want, exts)
+		}
+	}
+
+	configEngines := sourceConfigEngines(models)
+	if !slices.Contains(configEngines[schema.ModelSourceGo], scanner.EngineGo) {
+		t.Fatalf("expected Go model source config engines to include go, got %+v", configEngines)
+	}
+
+	queryEngines := sourceQueryEngines(models)
+	if !slices.Contains(queryEngines[scanner.EngineGoqu], schema.ModelSourceGo) {
+		t.Fatalf("expected goqu query engine to use Go model source, got %+v", queryEngines)
+	}
+
+	inputs := newScannerInputs()
+	seen := make(map[string]map[string]struct{})
+	addInputFile(inputs, seen, ".go", "b.GO")
+	addInputFile(inputs, seen, ".cs", "a.cs")
+	addInputFile(inputs, seen, ".txt", "ignored.txt")
+	files := inputs.filesForExtensions([]string{"go", ".cs"})
+	if want := []string{"a.cs", "b.GO"}; !slices.Equal(files, want) {
+		t.Fatalf("filesForExtensions() = %+v, want %+v", files, want)
+	}
+
+	if got := normalizeExt("CS"); got != ".cs" {
+		t.Fatalf("normalizeExt() = %q, want .cs", got)
+	}
+}
+
+func TestSourceBindingAllDisabledKeepsRawSQLDisabled(t *testing.T) {
+	cfg := config.Default()
+	cfg.Sources = map[string]bool{
+		"sql":        false,
+		"go":         false,
+		"goqu":       false,
+		"sqlalchemy": false,
+		"csharp":     false,
+	}
+
+	if scanners := filterScannerBindings(cfg, defaultScannerBindings()); len(scanners) != 0 {
+		t.Fatalf("expected all scanners disabled, got %+v", scanners)
+	}
+	if models := filterModelBindings(cfg, defaultModelBindings(cfg)); len(models) != 0 {
+		t.Fatalf("expected all model extractors disabled, got %+v", models)
 	}
 }

--- a/internal/output/sql_render.go
+++ b/internal/output/sql_render.go
@@ -124,6 +124,8 @@ func syntheticOriginLabel(source string) string {
 		return "SQLAlchemy query builder"
 	case "goqu-ast":
 		return "goqu query builder"
+	case "csharp-efcore":
+		return "C# EF Core query builder"
 	case "":
 		return ""
 	default:

--- a/internal/output/sql_render_test.go
+++ b/internal/output/sql_render_test.go
@@ -86,6 +86,7 @@ func TestSyntheticOriginLabel(t *testing.T) {
 		{source: "", want: ""},
 		{source: "sqlalchemy-ast", want: "SQLAlchemy query builder"},
 		{source: "goqu-ast", want: "goqu query builder"},
+		{source: "csharp-efcore", want: "C# EF Core query builder"},
 		{source: "custom-ast", want: "synthetic query builder"},
 	}
 

--- a/internal/rules/helpers.go
+++ b/internal/rules/helpers.go
@@ -142,7 +142,7 @@ func hasLimitClause(parsed *postgresparser.ParsedQuery) bool {
 
 // queryClauses returns predicate-bearing clause text used for pattern checks.
 func queryClauses(parsed *postgresparser.ParsedQuery) []string {
-	var clauses []string
+	clauses := make([]string, 0, len(parsed.Where)+len(parsed.Having)+len(parsed.JoinConditions))
 	clauses = append(clauses, parsed.Where...)
 	clauses = append(clauses, parsed.Having...)
 	clauses = append(clauses, parsed.JoinConditions...)

--- a/internal/scanner/csharp/roslynextractor/Program.cs
+++ b/internal/scanner/csharp/roslynextractor/Program.cs
@@ -1,0 +1,1313 @@
+// Copyright 2025 ValkDB
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+/// <summary>
+/// Roslyn-based extractor for EF Core raw SQL calls and deterministic DbSet/LINQ query chains.
+/// </summary>
+internal static class Program
+{
+    private const string SyntheticPrefix = "/* valk-guard:synthetic csharp-efcore */ ";
+
+    private static readonly HashSet<string> RawSqlMethods = new(StringComparer.Ordinal)
+    {
+        "ExecuteSqlRaw", "ExecuteSqlRawAsync", "ExecuteSqlInterpolated", "ExecuteSqlInterpolatedAsync",
+        "FromSqlRaw", "FromSqlInterpolated", "SqlQueryRaw", "SqlQueryInterpolated",
+    };
+
+    private static readonly HashSet<string> TerminalMethods = new(StringComparer.Ordinal)
+    {
+        "ToList", "ToListAsync", "ToArray", "ToArrayAsync", "First", "FirstAsync",
+        "FirstOrDefault", "FirstOrDefaultAsync", "Single", "SingleAsync", "SingleOrDefault",
+        "SingleOrDefaultAsync", "Any", "AnyAsync", "All", "AllAsync", "Count", "CountAsync",
+        "Sum", "SumAsync", "Min", "MinAsync", "Max", "MaxAsync", "Average", "AverageAsync",
+        "ExecuteDelete", "ExecuteDeleteAsync", "ExecuteUpdate", "ExecuteUpdateAsync",
+    };
+
+    /// <summary>
+    /// Parses all input files and prints JSON extraction results to stdout.
+    /// </summary>
+    public static int Main(string[] args)
+    {
+        var results = new List<SqlResult>();
+        foreach (var file in args)
+        {
+            try
+            {
+                results.AddRange(ExtractFile(file));
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                Console.Error.WriteLine($"{file}: {ex.Message}");
+                return 2;
+            }
+        }
+
+        Console.Write(JsonSerializer.Serialize(results));
+        return 0;
+    }
+
+    /// <summary>
+    /// Extracts raw and synthetic SQL statements from a single C# source file.
+    /// </summary>
+    private static IEnumerable<SqlResult> ExtractFile(string file)
+    {
+        var source = File.ReadAllText(file);
+        var tree = CSharpSyntaxTree.ParseText(source, path: file);
+        var root = tree.GetRoot();
+        var tableMap = BuildTableMap(root);
+        var results = new List<SqlResult>();
+
+        foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (TryExtractRawSql(file, invocation, out var rawResult))
+            {
+                results.Add(rawResult);
+                continue;
+            }
+
+            if (TrySynthesizeQuerySql(file, invocation, tableMap, out var syntheticResult))
+            {
+                results.Add(syntheticResult);
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Extracts SQL from EF Core raw SQL APIs when the first argument resolves to a static string.
+    /// </summary>
+    private static bool TryExtractRawSql(string file, InvocationExpressionSyntax invocation, out SqlResult result)
+    {
+        result = default!;
+        if (!TryGetInvokedMember(invocation, out var member))
+        {
+            return false;
+        }
+
+        var method = MethodName(member.Name);
+        if (!RawSqlMethods.Contains(method) || !ReceiverLooksLikeEfCore(method, member.Expression, invocation))
+        {
+            return false;
+        }
+        if (invocation.ArgumentList.Arguments.Count == 0)
+        {
+            return false;
+        }
+
+        var locals = CollectLocalFragments(invocation);
+        var placeholders = 1;
+        var firstArg = invocation.ArgumentList.Arguments[0].Expression;
+        if (!TryEvaluateString(firstArg, locals, ref placeholders, out var sql))
+        {
+            return false;
+        }
+        if (!method.Contains("Interpolated", StringComparison.Ordinal))
+        {
+            sql = NormalizeFormatPlaceholders(sql, invocation.ArgumentList.Arguments.Count - 1);
+        }
+
+        sql = NormalizeSql(sql);
+        if (!LooksLikeSql(sql))
+        {
+            return false;
+        }
+
+        result = BuildResult(file, invocation, sql);
+        return true;
+    }
+
+    /// <summary>
+    /// Generates representative SQL for deterministic EF Core DbSet/LINQ query chains.
+    /// </summary>
+    private static bool TrySynthesizeQuerySql(
+        string file,
+        InvocationExpressionSyntax invocation,
+        IReadOnlyDictionary<string, string> tableMap,
+        out SqlResult result)
+    {
+        result = default!;
+        var chain = UnwindChain(invocation);
+        if (chain.Calls.Count == 0)
+        {
+            return false;
+        }
+
+        var terminal = chain.Calls[^1].Name;
+        if (!TerminalMethods.Contains(terminal) || chain.Calls.Any(call => RawSqlMethods.Contains(call.Name)))
+        {
+            return false;
+        }
+
+        var table = ExtractBaseTable(chain, tableMap);
+        if (table is null)
+        {
+            return false;
+        }
+
+        var sql = RenderQuery(chain, table, terminal, tableMap);
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            return false;
+        }
+
+        result = BuildResult(file, invocation, SyntheticPrefix + sql);
+        return true;
+    }
+
+    /// <summary>
+    /// Builds an entity type to table-name map from attributes and simple Fluent API table configuration.
+    /// </summary>
+    private static Dictionary<string, string> BuildTableMap(SyntaxNode root)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var cls in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
+        {
+            foreach (var list in cls.AttributeLists)
+            {
+                foreach (var attr in list.Attributes)
+                {
+                    var name = attr.Name.ToString();
+                    if (!name.EndsWith("Table", StringComparison.Ordinal) && !name.EndsWith("TableAttribute", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+                    var table = attr.ArgumentList?.Arguments.FirstOrDefault()?.Expression is LiteralExpressionSyntax lit
+                        ? lit.Token.ValueText
+                        : string.Empty;
+                    var schema = attr.ArgumentList?.Arguments
+                        .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.ValueText == "Schema")?.Expression is LiteralExpressionSyntax schemaLit
+                            ? schemaLit.Token.ValueText
+                            : string.Empty;
+                    if (!string.IsNullOrWhiteSpace(table))
+                    {
+                        map[cls.Identifier.ValueText] = string.IsNullOrWhiteSpace(schema) ? SafeIdentifier(table, cls.Identifier.ValueText) : SafeIdentifier(schema + "." + table, cls.Identifier.ValueText);
+                    }
+                }
+            }
+        }
+
+        foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (!TryGetInvokedMember(invocation, out var member) || MethodName(member.Name) != "ToTable" || invocation.ArgumentList.Arguments.Count == 0)
+            {
+                continue;
+            }
+            if (invocation.ArgumentList.Arguments[0].Expression is not LiteralExpressionSyntax tableLiteral)
+            {
+                continue;
+            }
+            var table = SafeIdentifier(tableLiteral.Token.ValueText, "entity");
+            if (member.Expression is InvocationExpressionSyntax entityCall && TryGetGenericTypeName(entityCall, out var entityType))
+            {
+                map[entityType] = table;
+                continue;
+            }
+            if (member.Expression is IdentifierNameSyntax receiver)
+            {
+                var lambda = invocation.FirstAncestorOrSelf<SimpleLambdaExpressionSyntax>()
+                    ?? invocation.FirstAncestorOrSelf<ParenthesizedLambdaExpressionSyntax>() as LambdaExpressionSyntax;
+                if (lambda is not null && LambdaParameterName(lambda) == receiver.Identifier.ValueText)
+                {
+                    var entityInvocation = lambda.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+                    if (entityInvocation is not null && TryGetGenericTypeName(entityInvocation, out entityType))
+                    {
+                        map[entityType] = table;
+                    }
+                }
+            }
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Applies conservative receiver checks for raw EF Core SQL APIs.
+    /// </summary>
+    private static bool ReceiverLooksLikeEfCore(string method, ExpressionSyntax receiver, InvocationExpressionSyntax invocation)
+    {
+        if (method.StartsWith("FromSql", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        receiver = UnwrapExpression(receiver);
+        if (receiver is MemberAccessExpressionSyntax member && MethodName(member.Name) == "Database")
+        {
+            return true;
+        }
+
+        return receiver is IdentifierNameSyntax identifier && IsDatabaseFacadeName(invocation, identifier.Identifier.ValueText);
+    }
+
+    /// <summary>
+    /// Reports whether the closest visible declaration/assignment before the call makes name a DatabaseFacade.
+    /// </summary>
+    private static bool IsDatabaseFacadeName(InvocationExpressionSyntax invocation, string name)
+    {
+        var method = invocation.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>();
+        if (method is not null)
+        {
+            foreach (var parameter in method.ParameterList.Parameters)
+            {
+                if (parameter.Identifier.ValueText == name && parameter.Type?.ToString().EndsWith("DatabaseFacade", StringComparison.Ordinal) == true)
+                {
+                    return true;
+                }
+            }
+        }
+
+        var scope = method as SyntaxNode ?? invocation.SyntaxTree.GetRoot();
+        var invocationBlock = invocation.FirstAncestorOrSelf<BlockSyntax>();
+        bool? closest = null;
+        foreach (var node in scope.DescendantNodes().Where(node => node.Span.End < invocation.SpanStart).OrderBy(node => node.SpanStart))
+        {
+            if (node is LocalDeclarationStatementSyntax local)
+            {
+                if (invocationBlock is not null && local.FirstAncestorOrSelf<BlockSyntax>() != invocationBlock)
+                {
+                    continue;
+                }
+                foreach (var variable in local.Declaration.Variables)
+                {
+                    if (variable.Identifier.ValueText == name)
+                    {
+                        closest = local.Declaration.Type.ToString().EndsWith("DatabaseFacade", StringComparison.Ordinal)
+                            || (variable.Initializer is not null && IsDatabaseProperty(variable.Initializer.Value));
+                    }
+                }
+            }
+            else if (node is AssignmentExpressionSyntax assignment && assignment.Left is IdentifierNameSyntax identifier && identifier.Identifier.ValueText == name)
+            {
+                if (IsConditionalFlow(assignment, method))
+                {
+                    return false;
+                }
+                closest = IsDatabaseProperty(assignment.Right);
+            }
+        }
+        return closest == true;
+    }
+
+
+    /// <summary>
+    /// Reports whether an assignment is inside conditional control flow before a call site.
+    /// </summary>
+    private static bool IsConditionalFlow(SyntaxNode node, BaseMethodDeclarationSyntax? method)
+    {
+        foreach (var ancestor in node.Ancestors())
+        {
+            if (method is not null && ancestor == method)
+            {
+                return false;
+            }
+            if (ancestor is IfStatementSyntax or SwitchStatementSyntax or ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Reports whether expression syntactically references DbContext.Database.
+    /// </summary>
+    private static bool IsDatabaseProperty(ExpressionSyntax expression)
+    {
+        expression = UnwrapExpression(expression);
+        return expression is MemberAccessExpressionSyntax member && MethodName(member.Name) == "Database";
+    }
+
+    /// <summary>
+    /// Collects local string expression fragments visible before an invocation without flattening interpolation.
+    /// </summary>
+    private static Dictionary<string, ExpressionSyntax> CollectLocalFragments(InvocationExpressionSyntax invocation)
+    {
+        var locals = new Dictionary<string, ExpressionSyntax>(StringComparer.Ordinal);
+        var scope = invocation.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>() as SyntaxNode ?? invocation.SyntaxTree.GetRoot();
+        var nodes = scope.DescendantNodes()
+            .Where(node => node.Span.End < invocation.SpanStart)
+            .Where(node => node is LocalDeclarationStatementSyntax or AssignmentExpressionSyntax)
+            .OrderBy(node => node.SpanStart);
+
+        foreach (var node in nodes)
+        {
+            if (node is LocalDeclarationStatementSyntax local)
+            {
+                foreach (var variable in local.Declaration.Variables)
+                {
+                    if (variable.Initializer is not null)
+                    {
+                        locals[variable.Identifier.ValueText] = variable.Initializer.Value;
+                    }
+                }
+            }
+            else if (node is AssignmentExpressionSyntax assignment && assignment.Left is IdentifierNameSyntax identifier)
+            {
+                locals[identifier.Identifier.ValueText] = assignment.Right;
+            }
+        }
+
+        return locals;
+    }
+
+    /// <summary>
+    /// Evaluates static SQL string expressions and allocates placeholders at the consuming call site.
+    /// </summary>
+    private static bool TryEvaluateString(ExpressionSyntax expression, IReadOnlyDictionary<string, ExpressionSyntax> locals, ref int nextPlaceholder, out string value)
+    {
+        return TryEvaluateString(expression, locals, new HashSet<string>(StringComparer.Ordinal), ref nextPlaceholder, out value);
+    }
+
+    /// <summary>
+    /// Evaluates literals, concatenation, locals, and interpolation while preventing recursive local cycles.
+    /// </summary>
+    private static bool TryEvaluateString(
+        ExpressionSyntax expression,
+        IReadOnlyDictionary<string, ExpressionSyntax> locals,
+        HashSet<string> resolving,
+        ref int nextPlaceholder,
+        out string value)
+    {
+        value = string.Empty;
+        expression = UnwrapExpression(expression);
+        if (expression is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.StringLiteralExpression))
+        {
+            value = literal.Token.ValueText;
+            return true;
+        }
+        if (expression is InterpolatedStringExpressionSyntax interpolated)
+        {
+            var parts = new List<string>();
+            foreach (var content in interpolated.Contents)
+            {
+                if (content is InterpolatedStringTextSyntax text)
+                {
+                    parts.Add(text.TextToken.ValueText);
+                }
+                else if (content is InterpolationSyntax)
+                {
+                    parts.Add($"${nextPlaceholder++}");
+                }
+            }
+            value = string.Concat(parts);
+            return true;
+        }
+        if (expression is BinaryExpressionSyntax binary && binary.IsKind(SyntaxKind.AddExpression))
+        {
+            if (!TryEvaluateString(binary.Left, locals, resolving, ref nextPlaceholder, out var left))
+            {
+                return false;
+            }
+            if (!TryEvaluateString(binary.Right, locals, resolving, ref nextPlaceholder, out var right))
+            {
+                return false;
+            }
+            value = left + right;
+            return true;
+        }
+        if (expression is IdentifierNameSyntax identifier && locals.TryGetValue(identifier.Identifier.ValueText, out var localExpression))
+        {
+            var localName = identifier.Identifier.ValueText;
+            if (!resolving.Add(localName))
+            {
+                return false;
+            }
+            var ok = TryEvaluateString(localExpression, locals, resolving, ref nextPlaceholder, out value);
+            resolving.Remove(localName);
+            return ok;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Converts nested invocation/member syntax into an ordered query chain.
+    /// </summary>
+    private static QueryChain UnwindChain(InvocationExpressionSyntax invocation)
+    {
+        var calls = new List<QueryCall>();
+        ExpressionSyntax current = invocation;
+        while (current is InvocationExpressionSyntax currentInvocation && currentInvocation.Expression is MemberAccessExpressionSyntax member)
+        {
+            calls.Add(new QueryCall(MethodName(member.Name), currentInvocation));
+            current = member.Expression;
+        }
+        calls.Reverse();
+        return new QueryChain(current, calls);
+    }
+
+    /// <summary>
+    /// Renders the collected query chain as parser-friendly synthetic SQL.
+    /// </summary>
+    private static string RenderQuery(QueryChain chain, string table, string terminal, IReadOnlyDictionary<string, string> tableMap)
+    {
+        var state = new QueryState(table);
+        var binds = new PlaceholderAllocator();
+        var afterGroupBy = false;
+
+        foreach (var call in chain.Calls)
+        {
+            var name = call.Name;
+            var args = call.Invocation.ArgumentList.Arguments.Select(arg => arg.Expression).ToArray();
+            switch (name)
+            {
+                case "Distinct":
+                    state.Distinct = true;
+                    break;
+                case "Select":
+                    state.Columns = ExtractSelectColumns(args);
+                    break;
+                case "Take":
+                    state.Limit = LiteralText(args.FirstOrDefault()) ?? "1";
+                    break;
+                case "Skip":
+                    state.Offset = LiteralText(args.FirstOrDefault()) ?? "1";
+                    break;
+                case "OrderBy":
+                case "ThenBy":
+                case "OrderByDescending":
+                case "ThenByDescending":
+                    if (args.Length > 0 && ColumnFromLambda(args[0]) is { } orderCol)
+                    {
+                        state.OrderBy.Add(orderCol + (name.EndsWith("Descending", StringComparison.Ordinal) ? " DESC" : " ASC"));
+                    }
+                    break;
+                case "GroupBy":
+                    if (args.Length > 0 && ColumnFromLambda(args[0]) is { } groupCol)
+                    {
+                        state.GroupBy.Add(groupCol);
+                        afterGroupBy = true;
+                    }
+                    break;
+                case "Where":
+                    if (args.Length > 0 && PredicateFromExpression(LambdaBody(args[0]), binds) is { } predicate)
+                    {
+                        if (afterGroupBy)
+                        {
+                            state.Having.Add(predicate);
+                        }
+                        else
+                        {
+                            state.Where.Add(predicate);
+                        }
+                    }
+                    break;
+                case "Join":
+                    AddJoin(state, "JOIN", args, tableMap);
+                    break;
+                case "GroupJoin":
+                    AddJoin(state, "LEFT JOIN", args, tableMap);
+                    break;
+                case "SelectMany":
+                    if (!state.Joins.Any(join => join.Kind == "LEFT JOIN") && args.Length > 0)
+                    {
+                        var crossTable = TableFromLambda(args[0], tableMap) ?? "synthetic_join";
+                        state.Joins.Add(new JoinClause("CROSS JOIN", crossTable, null));
+                    }
+                    break;
+                case "Include":
+                case "ThenInclude":
+                    if (args.Length > 0 && ColumnFromLambda(args[0]) is { } includeTable)
+                    {
+                        state.Joins.Add(new JoinClause("LEFT JOIN", SafeIdentifier(includeTable, "joined"), null));
+                    }
+                    break;
+                case "ForUpdate":
+                case "LockingClause":
+                    state.ForUpdate = true;
+                    break;
+            }
+        }
+
+        if (terminal.StartsWith("ExecuteDelete", StringComparison.Ordinal))
+        {
+            return BuildDeleteSql(state);
+        }
+        if (terminal.StartsWith("ExecuteUpdate", StringComparison.Ordinal))
+        {
+            state.Columns = ExtractUpdateSetColumns(chain.Calls[^1].Invocation);
+            return BuildUpdateSql(state);
+        }
+
+        ApplyTerminalProjection(state, terminal, chain.Calls[^1].Invocation, binds);
+        return BuildSelectSql(state);
+    }
+
+    /// <summary>
+    /// Adds a join clause using table and key selector arguments when available.
+    /// </summary>
+    private static void AddJoin(QueryState state, string kind, IReadOnlyList<ExpressionSyntax> args, IReadOnlyDictionary<string, string> tableMap)
+    {
+        if (args.Count == 0)
+        {
+            return;
+        }
+        var table = TableFromExpression(args[0], tableMap) ?? "synthetic_join";
+        string? on = null;
+        if (args.Count >= 3)
+        {
+            var left = ColumnFromLambda(args[1]);
+            var right = ColumnFromLambda(args[2]);
+            if (!string.IsNullOrWhiteSpace(left) && !string.IsNullOrWhiteSpace(right))
+            {
+                on = left + " = " + right;
+            }
+        }
+        state.Joins.Add(new JoinClause(kind, table, on));
+    }
+
+    /// <summary>
+    /// Applies terminal aggregate or bounded-row projection behavior.
+    /// </summary>
+    private static void ApplyTerminalProjection(QueryState state, string terminal, InvocationExpressionSyntax invocation, PlaceholderAllocator placeholders)
+    {
+        var args = invocation.ArgumentList.Arguments.Select(arg => arg.Expression).ToArray();
+        var normalized = terminal.EndsWith("Async", StringComparison.Ordinal) ? terminal[..^5] : terminal;
+        switch (normalized)
+        {
+            case "Count":
+                state.Columns = new List<string> { "COUNT(*)" };
+                break;
+            case "Any":
+                state.Columns = new List<string> { "1" };
+                state.Limit ??= "1";
+                if (args.Length > 0 && PredicateFromExpression(LambdaBody(args[0]), placeholders) is { } anyPredicate)
+                {
+                    state.Where.Add(anyPredicate);
+                }
+                break;
+            case "All":
+                state.Columns = new List<string> { "1" };
+                state.Limit ??= "1";
+                if (args.Length > 0 && PredicateFromExpression(LambdaBody(args[0]), placeholders) is { } allPredicate)
+                {
+                    state.Where.Add(allPredicate);
+                }
+                break;
+            case "Sum":
+            case "Min":
+            case "Max":
+            case "Average":
+                var aggregateColumn = args.Length > 0 ? ColumnFromLambda(args[0]) ?? "synthetic_col" : "synthetic_col";
+                var fn = normalized == "Average" ? "AVG" : normalized.ToUpperInvariant();
+                state.Columns = new List<string> { $"{fn}({aggregateColumn})" };
+                break;
+            case "First":
+            case "FirstOrDefault":
+            case "Single":
+            case "SingleOrDefault":
+                state.Limit ??= "1";
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Builds a synthetic SELECT statement with projections, joins, predicates, ordering, and bounds.
+    /// </summary>
+    private static string BuildSelectSql(QueryState state)
+    {
+        var columns = state.Columns.Count > 0 ? string.Join(", ", state.Columns) : "*";
+        var distinct = state.Distinct ? "DISTINCT " : string.Empty;
+        var sql = $"SELECT {distinct}{columns} FROM {state.Table}";
+        if (state.Joins.Count > 0)
+        {
+            sql += " " + string.Join(" ", state.Joins.Select(join => join.ToSql()));
+        }
+        if (state.Where.Count > 0)
+        {
+            sql += " WHERE " + string.Join(" AND ", state.Where);
+        }
+        if (state.GroupBy.Count > 0)
+        {
+            sql += " GROUP BY " + string.Join(", ", state.GroupBy);
+        }
+        if (state.Having.Count > 0)
+        {
+            sql += " HAVING " + string.Join(" AND ", state.Having);
+        }
+        if (state.OrderBy.Count > 0)
+        {
+            sql += " ORDER BY " + string.Join(", ", state.OrderBy);
+        }
+        if (state.Limit is not null)
+        {
+            sql += " LIMIT " + state.Limit;
+        }
+        if (state.Offset is not null)
+        {
+            sql += " OFFSET " + state.Offset;
+        }
+        if (state.ForUpdate)
+        {
+            sql += " FOR UPDATE";
+        }
+        return sql;
+    }
+
+    /// <summary>
+    /// Builds a synthetic DELETE statement, preserving explicit query joins and predicates.
+    /// </summary>
+    private static string BuildDeleteSql(QueryState state)
+    {
+        var sql = $"DELETE FROM {state.Table}";
+        var joinedTables = state.Joins.Where(join => join.Kind != "LEFT JOIN" || join.On is not null).Select(join => join.Table).ToArray();
+        if (joinedTables.Length > 0)
+        {
+            sql += " USING " + string.Join(", ", joinedTables);
+        }
+        if (state.Where.Count > 0)
+        {
+            sql += " WHERE " + string.Join(" AND ", state.Where);
+        }
+        return sql;
+    }
+
+    /// <summary>
+    /// Builds a synthetic UPDATE statement with a parser-safe SET clause.
+    /// </summary>
+    private static string BuildUpdateSql(QueryState state)
+    {
+        var setColumn = state.Columns.FirstOrDefault(column => column != "*") ?? "synthetic_col";
+        var sql = $"UPDATE {state.Table} SET {setColumn} = $1";
+        var joinedTables = state.Joins.Where(join => join.Kind != "LEFT JOIN" || join.On is not null).Select(join => join.Table).ToArray();
+        if (joinedTables.Length > 0)
+        {
+            sql += " FROM " + string.Join(", ", joinedTables);
+        }
+        if (state.Where.Count > 0)
+        {
+            sql += " WHERE " + string.Join(" AND ", state.Where);
+        }
+        return sql;
+    }
+
+    /// <summary>
+    /// Extracts columns targeted by ExecuteUpdate SetProperty calls when visible in the AST.
+    /// </summary>
+    private static List<string> ExtractUpdateSetColumns(InvocationExpressionSyntax invocation)
+    {
+        var columns = new List<string>();
+        foreach (var setProperty in invocation.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (!TryGetInvokedMember(setProperty, out var member) || MethodName(member.Name) != "SetProperty")
+            {
+                continue;
+            }
+            if (setProperty.ArgumentList.Arguments.Count == 0)
+            {
+                continue;
+            }
+            var column = ColumnFromLambda(setProperty.ArgumentList.Arguments[0].Expression);
+            if (!string.IsNullOrWhiteSpace(column))
+            {
+                columns.Add(column);
+            }
+        }
+        return columns.Count == 0 ? new List<string> { "synthetic_col" } : columns.Distinct(StringComparer.Ordinal).ToList();
+    }
+
+    /// <summary>
+    /// Extracts the base table from DbSet member access or DbContext.Set&lt;T&gt;().
+    /// </summary>
+    private static string? ExtractBaseTable(QueryChain chain, IReadOnlyDictionary<string, string> tableMap)
+    {
+        foreach (var call in chain.Calls)
+        {
+            if (call.Name == "Set" && TryGetGenericTypeName(call.Invocation, out var setType))
+            {
+                return ResolveTable(setType, tableMap);
+            }
+        }
+        return TableFromExpression(chain.BaseExpression, tableMap);
+    }
+
+    /// <summary>
+    /// Extracts projection columns from Select(lambda) calls when statically recognizable.
+    /// </summary>
+    private static List<string> ExtractSelectColumns(IReadOnlyList<ExpressionSyntax> args)
+    {
+        if (args.Count == 0)
+        {
+            return new List<string> { "*" };
+        }
+        var body = LambdaBody(args[0]) ?? args[0];
+        if (body is AnonymousObjectCreationExpressionSyntax anonymous)
+        {
+            var columns = anonymous.Initializers.Select(initializer => ColumnFromExpression(initializer.Expression)).WhereNotNull().Distinct(StringComparer.Ordinal).ToList();
+            return columns.Count == 0 ? new List<string> { "synthetic_col" } : columns;
+        }
+        return ColumnFromExpression(body) is { } singleColumn ? new List<string> { singleColumn } : new List<string> { "synthetic_col" };
+    }
+
+    /// <summary>
+    /// Converts a recognizable C# predicate expression into a SQL predicate.
+    /// </summary>
+    private static string? PredicateFromExpression(ExpressionSyntax? expression, PlaceholderAllocator placeholders)
+    {
+        if (expression is null)
+        {
+            return null;
+        }
+        expression = UnwrapExpression(expression);
+        if (expression is PrefixUnaryExpressionSyntax prefix && prefix.IsKind(SyntaxKind.LogicalNotExpression))
+        {
+            var inner = PredicateFromExpression(prefix.Operand, placeholders);
+            return inner is null ? null : $"NOT ({inner})";
+        }
+        if (expression is BinaryExpressionSyntax binary)
+        {
+            if (binary.IsKind(SyntaxKind.LogicalAndExpression) || binary.IsKind(SyntaxKind.LogicalOrExpression))
+            {
+                var left = PredicateFromExpression(binary.Left, placeholders);
+                var right = PredicateFromExpression(binary.Right, placeholders);
+                if (left is null || right is null)
+                {
+                    return left ?? right;
+                }
+                return $"({left}) {(binary.IsKind(SyntaxKind.LogicalAndExpression) ? "AND" : "OR")} ({right})";
+            }
+            var column = ColumnFromExpression(binary.Left);
+            var value = SqlValue(binary.Right, placeholders);
+            var op = SqlOperator(binary.Kind());
+            if (column is not null && value is not null && op is not null)
+            {
+                return $"{column} {op} {value}";
+            }
+        }
+        if (expression is InvocationExpressionSyntax invocation)
+        {
+            return PredicateFromInvocation(invocation, placeholders);
+        }
+        return ColumnFromExpression(expression) is { } boolColumn ? $"{boolColumn} = TRUE" : null;
+    }
+
+    /// <summary>
+    /// Converts invocation predicates such as Like, Contains, and collection Contains into SQL predicates.
+    /// </summary>
+    private static string? PredicateFromInvocation(InvocationExpressionSyntax invocation, PlaceholderAllocator placeholders)
+    {
+        if (!TryGetInvokedMember(invocation, out var member))
+        {
+            return null;
+        }
+        var method = MethodName(member.Name);
+        if (method is "Like" or "ILike" && invocation.ArgumentList.Arguments.Count >= 2 && IsEfFunctionsReceiver(member.Expression))
+        {
+            var column = ColumnFromExpression(invocation.ArgumentList.Arguments[0].Expression);
+            var pattern = StringPattern(invocation.ArgumentList.Arguments[1].Expression, PatternKind.Exact, placeholders);
+            var op = method == "ILike" ? "ILIKE" : "LIKE";
+            return column is null || pattern is null ? null : $"{column} {op} {pattern}";
+        }
+        if (method is "Contains" or "StartsWith" or "EndsWith" && invocation.ArgumentList.Arguments.Count > 0)
+        {
+            var argColumn = ColumnFromExpression(invocation.ArgumentList.Arguments[0].Expression);
+            if (method == "Contains" && argColumn is not null && member.Expression is not MemberAccessExpressionSyntax)
+            {
+                return $"{argColumn} IN ({SyntheticBindList(member.Expression, placeholders)})";
+            }
+            var receiverColumn = ColumnFromExpression(member.Expression);
+            var kind = method switch
+            {
+                "Contains" => PatternKind.Contains,
+                "StartsWith" => PatternKind.StartsWith,
+                "EndsWith" => PatternKind.EndsWith,
+                _ => PatternKind.Exact,
+            };
+            var pattern = StringPattern(invocation.ArgumentList.Arguments[0].Expression, kind, placeholders);
+            return receiverColumn is null || pattern is null ? null : $"{receiverColumn} LIKE {pattern}";
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Produces a bind placeholder list, using static collection arity when available.
+    /// </summary>
+    private static string SyntheticBindList(ExpressionSyntax collection, PlaceholderAllocator placeholders)
+    {
+        var arity = 3;
+        collection = UnwrapExpression(collection);
+        if (collection is ImplicitArrayCreationExpressionSyntax implicitArray)
+        {
+            arity = Math.Max(1, implicitArray.Initializer.Expressions.Count);
+        }
+        else if (collection is ArrayCreationExpressionSyntax array && array.Initializer is not null)
+        {
+            arity = Math.Max(1, array.Initializer.Expressions.Count);
+        }
+        else if (collection is ObjectCreationExpressionSyntax obj && obj.Initializer is not null)
+        {
+            arity = Math.Max(1, obj.Initializer.Expressions.Count);
+        }
+        return string.Join(", ", Enumerable.Range(0, arity).Select(_ => placeholders.Next()));
+    }
+
+    /// <summary>
+    /// Converts a static expression into a SQL literal or placeholder.
+    /// </summary>
+    private static string? SqlValue(ExpressionSyntax expression, PlaceholderAllocator placeholders)
+    {
+        expression = UnwrapExpression(expression);
+        if (expression is LiteralExpressionSyntax literal)
+        {
+            if (literal.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                return QuoteString(literal.Token.ValueText);
+            }
+            if (literal.IsKind(SyntaxKind.TrueLiteralExpression))
+            {
+                return "TRUE";
+            }
+            if (literal.IsKind(SyntaxKind.FalseLiteralExpression))
+            {
+                return "FALSE";
+            }
+            if (literal.IsKind(SyntaxKind.NullLiteralExpression))
+            {
+                return "NULL";
+            }
+            return literal.Token.ValueText;
+        }
+        return expression is IdentifierNameSyntax or MemberAccessExpressionSyntax or InvocationExpressionSyntax ? placeholders.Next() : null;
+    }
+
+    /// <summary>
+    /// Converts a string expression into a quoted SQL LIKE pattern.
+    /// </summary>
+    private static string? StringPattern(ExpressionSyntax expression, PatternKind kind, PlaceholderAllocator placeholders)
+    {
+        expression = UnwrapExpression(expression);
+        if (expression is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.StringLiteralExpression))
+        {
+            var value = literal.Token.ValueText;
+            value = kind switch
+            {
+                PatternKind.Contains => "%" + value + "%",
+                PatternKind.StartsWith => value + "%",
+                PatternKind.EndsWith => "%" + value,
+                _ => value,
+            };
+            return QuoteString(value);
+        }
+        return expression is IdentifierNameSyntax or MemberAccessExpressionSyntax or InvocationExpressionSyntax ? placeholders.Next() : null;
+    }
+
+    /// <summary>
+    /// Extracts a SQL column-like identifier from member access or identifier syntax.
+    /// </summary>
+    private static string? ColumnFromExpression(ExpressionSyntax expression)
+    {
+        expression = UnwrapExpression(expression);
+        if (expression is MemberAccessExpressionSyntax member)
+        {
+            return SafeIdentifier(MethodName(member.Name), "col");
+        }
+        if (expression is IdentifierNameSyntax identifier)
+        {
+            return SafeIdentifier(identifier.Identifier.ValueText, "col");
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts a column identifier from a lambda expression body.
+    /// </summary>
+    private static string? ColumnFromLambda(ExpressionSyntax expression)
+    {
+        return LambdaBody(expression) is { } body ? ColumnFromExpression(body) : ColumnFromExpression(expression);
+    }
+
+    /// <summary>
+    /// Extracts a table identifier from a lambda expression body.
+    /// </summary>
+    private static string? TableFromLambda(ExpressionSyntax expression, IReadOnlyDictionary<string, string> tableMap)
+    {
+        var body = LambdaBody(expression);
+        return body is null ? null : TableFromExpression(body, tableMap);
+    }
+
+    /// <summary>
+    /// Converts a DbSet-like expression into a SQL table identifier.
+    /// </summary>
+    private static string? TableFromExpression(ExpressionSyntax expression, IReadOnlyDictionary<string, string> tableMap)
+    {
+        expression = UnwrapExpression(expression);
+        if (expression is MemberAccessExpressionSyntax member)
+        {
+            return ResolveTable(MethodName(member.Name), tableMap);
+        }
+        if (expression is IdentifierNameSyntax identifier)
+        {
+            return ResolveTable(identifier.Identifier.ValueText, tableMap);
+        }
+        if (expression is InvocationExpressionSyntax invocation && TryGetGenericTypeName(invocation, out var genericType))
+        {
+            return ResolveTable(genericType, tableMap);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves an entity or DbSet identifier to its configured table name.
+    /// </summary>
+    private static string ResolveTable(string value, IReadOnlyDictionary<string, string> tableMap)
+    {
+        var rightmost = RightmostIdentifier(value);
+        if (tableMap.TryGetValue(rightmost, out var mapped))
+        {
+            return mapped;
+        }
+        if (rightmost.EndsWith("s", StringComparison.Ordinal) && tableMap.TryGetValue(rightmost[..^1], out mapped))
+        {
+            return mapped;
+        }
+        return SafeIdentifier(rightmost, "entity");
+    }
+
+    /// <summary>
+    /// Returns the expression body of a lambda expression.
+    /// </summary>
+    private static ExpressionSyntax? LambdaBody(ExpressionSyntax expression)
+    {
+        expression = UnwrapExpression(expression);
+        return expression switch
+        {
+            SimpleLambdaExpressionSyntax simple when simple.Body is ExpressionSyntax body => body,
+            ParenthesizedLambdaExpressionSyntax parenthesized when parenthesized.Body is ExpressionSyntax body => body,
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Returns the first parameter name of a lambda expression.
+    /// </summary>
+    private static string? LambdaParameterName(LambdaExpressionSyntax lambda)
+    {
+        return lambda switch
+        {
+            SimpleLambdaExpressionSyntax simple => simple.Parameter.Identifier.ValueText,
+            ParenthesizedLambdaExpressionSyntax parenthesized => parenthesized.ParameterList.Parameters.FirstOrDefault()?.Identifier.ValueText,
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Extracts a generic type name from an invocation such as Set&lt;User&gt;().
+    /// </summary>
+    private static bool TryGetGenericTypeName(InvocationExpressionSyntax invocation, out string typeName)
+    {
+        typeName = string.Empty;
+        if (invocation.Expression is not MemberAccessExpressionSyntax member || member.Name is not GenericNameSyntax generic || generic.TypeArgumentList.Arguments.Count == 0)
+        {
+            return false;
+        }
+        typeName = TypeIdentifier(generic.TypeArgumentList.Arguments[0]);
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the rightmost type identifier from a possibly qualified generic type syntax.
+    /// </summary>
+    private static string TypeIdentifier(TypeSyntax type)
+    {
+        type = type is NullableTypeSyntax nullable ? nullable.ElementType : type;
+        return type switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+            GenericNameSyntax generic => generic.Identifier.ValueText,
+            QualifiedNameSyntax qualified => TypeIdentifier(qualified.Right),
+            AliasQualifiedNameSyntax aliasQualified => TypeIdentifier(aliasQualified.Name),
+            _ => RightmostIdentifier(type.ToString()),
+        };
+    }
+
+    /// <summary>
+    /// Extracts the rightmost identifier from fallback type text.
+    /// </summary>
+    private static string RightmostIdentifier(string text)
+    {
+        var candidate = text.Split('.').LastOrDefault() ?? text;
+        var genericStart = candidate.IndexOf('<', StringComparison.Ordinal);
+        return genericStart >= 0 ? candidate[..genericStart] : candidate;
+    }
+
+    /// <summary>
+    /// Returns the invoked member access for an invocation expression.
+    /// </summary>
+    private static bool TryGetInvokedMember(InvocationExpressionSyntax invocation, out MemberAccessExpressionSyntax member)
+    {
+        member = default!;
+        if (invocation.Expression is not MemberAccessExpressionSyntax candidate)
+        {
+            return false;
+        }
+        member = candidate;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns true when the expression is a reference to <c>EF.Functions</c>.
+    /// Recognizes the canonical Microsoft.EntityFrameworkCore receiver shape used by
+    /// <c>EF.Functions.Like</c> / <c>EF.Functions.ILike</c> and similar extension entry points.
+    /// </summary>
+    private static bool IsEfFunctionsReceiver(ExpressionSyntax? expression)
+    {
+        if (expression is not MemberAccessExpressionSyntax member)
+        {
+            return false;
+        }
+        if (MethodName(member.Name) != "Functions")
+        {
+            return false;
+        }
+        return member.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == "EF";
+    }
+
+    /// <summary>
+    /// Returns a method identifier from an identifier or generic method name syntax node.
+    /// </summary>
+    private static string MethodName(SimpleNameSyntax name)
+    {
+        return name switch
+        {
+            GenericNameSyntax generic => generic.Identifier.ValueText,
+            IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+            _ => name.ToString(),
+        };
+    }
+
+    /// <summary>
+    /// Removes syntactic wrappers that do not affect expression meaning for extraction.
+    /// </summary>
+    private static ExpressionSyntax UnwrapExpression(ExpressionSyntax expression)
+    {
+        while (expression is ParenthesizedExpressionSyntax parenthesized)
+        {
+            expression = parenthesized.Expression;
+        }
+        return expression;
+    }
+
+    /// <summary>
+    /// Converts ExecuteSqlRaw-style format placeholders to PostgreSQL placeholders.
+    /// </summary>
+    private static string NormalizeFormatPlaceholders(string sql, int valueArgumentCount)
+    {
+        for (var i = 0; i < valueArgumentCount; i++)
+        {
+            sql = sql.Replace("{" + i + "}", "$" + (i + 1), StringComparison.Ordinal);
+        }
+        return sql;
+    }
+
+    /// <summary>
+    /// Maps C# binary expression kinds to SQL operators.
+    /// </summary>
+    private static string? SqlOperator(SyntaxKind kind)
+    {
+        return kind switch
+        {
+            SyntaxKind.EqualsExpression => "=",
+            SyntaxKind.NotEqualsExpression => "<>",
+            SyntaxKind.GreaterThanExpression => ">",
+            SyntaxKind.GreaterThanOrEqualExpression => ">=",
+            SyntaxKind.LessThanExpression => "<",
+            SyntaxKind.LessThanOrEqualExpression => "<=",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Returns a literal expression value that is safe for LIMIT/OFFSET rendering.
+    /// </summary>
+    private static string? LiteralText(ExpressionSyntax? expression)
+    {
+        expression = expression is null ? null : UnwrapExpression(expression);
+        return expression is LiteralExpressionSyntax literal && literal.Token.Value is not null ? literal.Token.ValueText : null;
+    }
+
+    /// <summary>
+    /// Escapes a string for use as a SQL single-quoted literal.
+    /// </summary>
+    private static string QuoteString(string value)
+    {
+        return "'" + value.Replace("'", "''", StringComparison.Ordinal) + "'";
+    }
+
+    /// <summary>
+    /// Normalizes whitespace so generated SQL is parser-friendly and stable in tests.
+    /// </summary>
+    private static string NormalizeSql(string sql)
+    {
+        return string.Join(" ", sql.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)).Trim();
+    }
+
+    /// <summary>
+    /// Reports whether a string starts like SQL or a synthetic SQL comment.
+    /// </summary>
+    private static bool LooksLikeSql(string sql)
+    {
+        sql = sql.TrimStart();
+        if (sql.StartsWith("/*", StringComparison.Ordinal) || sql.StartsWith("--", StringComparison.Ordinal))
+        {
+            return true;
+        }
+        var firstSpace = sql.IndexOfAny(new[] { ' ', '\t', '\r', '\n' });
+        var first = firstSpace < 0 ? sql : sql[..firstSpace];
+        return first is "SELECT" or "INSERT" or "UPDATE" or "DELETE" or "CREATE" or "DROP" or "ALTER" or "TRUNCATE" or "WITH" or "GRANT" or "REVOKE" or "BEGIN" or "COMMIT" or "ROLLBACK" or "SET" or "COPY" or "VACUUM" or "ANALYZE" or "EXPLAIN" or "MERGE";
+    }
+
+    /// <summary>
+    /// Sanitizes an extracted identifier enough for synthetic SQL parsing.
+    /// </summary>
+    private static string SafeIdentifier(string value, string fallback)
+    {
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0)
+        {
+            return fallback;
+        }
+        var chars = trimmed.Where(ch => char.IsLetterOrDigit(ch) || ch == '_' || ch == '.').ToArray();
+        return chars.Length == 0 ? fallback : new string(chars);
+    }
+
+    /// <summary>
+    /// Builds a JSON result with one-based source coordinates from a syntax node.
+    /// </summary>
+    private static SqlResult BuildResult(string file, SyntaxNode node, string sql)
+    {
+        var span = node.GetLocation().GetLineSpan();
+        return new SqlResult
+        {
+            File = file,
+            Line = span.StartLinePosition.Line + 1,
+            Column = span.StartLinePosition.Character + 1,
+            EndLine = span.EndLinePosition.Line + 1,
+            EndColumn = span.EndLinePosition.Character + 1,
+            Sql = sql,
+        };
+    }
+
+    /// <summary>
+    /// Describes how a SQL LIKE pattern should be wrapped.
+    /// </summary>
+    private enum PatternKind
+    {
+        Exact,
+        Contains,
+        StartsWith,
+        EndsWith,
+    }
+
+    /// <summary>
+    /// Allocates stable PostgreSQL-style placeholders for one synthetic SQL statement.
+    /// </summary>
+    private sealed class PlaceholderAllocator
+    {
+        private int next = 1;
+
+        /// <summary>
+        /// Returns the next numbered bind placeholder.
+        /// </summary>
+        public string Next()
+        {
+            return "$" + next++;
+        }
+    }
+
+    /// <summary>
+    /// Mutable representation of one synthetic SQL statement while a chain is analyzed.
+    /// </summary>
+    private sealed class QueryState
+    {
+        /// <summary>
+        /// Creates a state object for a base table.
+        /// </summary>
+        public QueryState(string table)
+        {
+            Table = table;
+        }
+
+        public string Table { get; }
+        public bool Distinct { get; set; }
+        public bool ForUpdate { get; set; }
+        public string? Limit { get; set; }
+        public string? Offset { get; set; }
+        public List<string> Columns { get; set; } = new();
+        public List<JoinClause> Joins { get; } = new();
+        public List<string> Where { get; } = new();
+        public List<string> GroupBy { get; } = new();
+        public List<string> Having { get; } = new();
+        public List<string> OrderBy { get; } = new();
+    }
+
+    /// <summary>
+    /// Holds one method call in a fluent query chain.
+    /// </summary>
+    private sealed record QueryCall(string Name, InvocationExpressionSyntax Invocation);
+
+    /// <summary>
+    /// Holds the base expression and ordered calls for a fluent query chain.
+    /// </summary>
+    private sealed record QueryChain(ExpressionSyntax BaseExpression, List<QueryCall> Calls);
+
+    /// <summary>
+    /// Holds one synthetic SQL join target.
+    /// </summary>
+    private sealed record JoinClause(string Kind, string Table, string? On)
+    {
+        /// <summary>
+        /// Converts the join target to parser-friendly SQL.
+        /// </summary>
+        public string ToSql() => Kind == "CROSS JOIN" ? $"{Kind} {Table}" : $"{Kind} {Table} ON {On ?? "1=1"}";
+    }
+}
+
+/// <summary>
+/// LINQ helpers that keep nullable filtering terse without hiding scanner logic.
+/// </summary>
+internal static class EnumerableExtensions
+{
+    /// <summary>
+    /// Filters null strings from a sequence.
+    /// </summary>
+    public static IEnumerable<string> WhereNotNull(this IEnumerable<string?> values)
+    {
+        foreach (var value in values)
+        {
+            if (value is not null)
+            {
+                yield return value;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// JSON DTO for a single extracted SQL statement.
+/// </summary>
+internal sealed class SqlResult
+{
+    [JsonPropertyName("file")]
+    public string File { get; init; } = string.Empty;
+
+    [JsonPropertyName("line")]
+    public int Line { get; init; }
+
+    [JsonPropertyName("column")]
+    public int Column { get; init; }
+
+    [JsonPropertyName("end_line")]
+    public int EndLine { get; init; }
+
+    [JsonPropertyName("end_column")]
+    public int EndColumn { get; init; }
+
+    [JsonPropertyName("sql")]
+    public string Sql { get; init; } = string.Empty;
+}

--- a/internal/scanner/csharp/roslynextractor/RoslynExtractor.Tests/ExtractorGoldenTests.cs
+++ b/internal/scanner/csharp/roslynextractor/RoslynExtractor.Tests/ExtractorGoldenTests.cs
@@ -1,0 +1,185 @@
+// Copyright 2025 ValkDB
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace RoslynExtractor.Tests;
+
+public sealed class ExtractorGoldenTests
+{
+    [Fact]
+    public async Task RawSqlExtractionPreservesJsonEscapingAndLocation()
+    {
+        var source = """
+            class Repo {
+                void Run(MyDbContext db) {
+                    db.Database.ExecuteSqlRaw("SELECT \"name\", '\\\\path' FROM users WHERE note = 'line\\nnext'");
+                }
+            }
+            """;
+
+        var results = await ExtractAsync(source);
+
+        var result = Assert.Single(results);
+        Assert.Equal("SELECT \"name\", '\\\\path' FROM users WHERE note = 'line\\nnext'", result.Sql);
+        Assert.Equal(3, result.Line);
+        Assert.True(result.Column > 0);
+        Assert.True(result.EndColumn > result.Column);
+    }
+
+    [Fact]
+    public async Task MultiLineRawStringReportsEndLine()
+    {
+        var source = """"
+            class Repo {
+                void Run(MyDbContext db) {
+                    db.Database.ExecuteSqlRaw("""
+                        SELECT id
+                        FROM users
+                        WHERE active = true
+                        LIMIT 10
+                        """);
+                }
+            }
+            """";
+
+        var results = await ExtractAsync(source);
+
+        var result = Assert.Single(results);
+        Assert.Contains("SELECT id", result.Sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 10", result.Sql, StringComparison.Ordinal);
+        Assert.True(result.EndLine > result.Line, $"expected multi-line span, got {result.Line}:{result.Column}-{result.EndLine}:{result.EndColumn}");
+    }
+
+    [Fact]
+    public async Task TerminalMethodsProduceSyntheticSql()
+    {
+        var source = """
+            class Repo {
+                void Run(MyDbContext db) {
+                    db.Users.Take(1).ToList();
+                    db.Users.Take(1).ToArray();
+                    db.Users.Where(u => u.Id == 1).First();
+                    db.Users.Where(u => u.Id == 1).FirstOrDefault();
+                    db.Users.Where(u => u.Id == 1).Single();
+                    db.Users.Where(u => u.Id == 1).SingleOrDefault();
+                    db.Users.ExecuteDelete();
+                    db.Users.ExecuteUpdate(s => s.SetProperty(u => u.Active, false));
+                }
+            }
+            """;
+
+        var sql = (await ExtractAsync(source)).Select(result => result.Sql).ToArray();
+
+        Assert.Contains(sql, text => text.Contains("SELECT * FROM Users LIMIT 1", StringComparison.Ordinal));
+        Assert.Contains(sql, text => text.Contains("DELETE FROM Users", StringComparison.Ordinal));
+        Assert.Contains(sql, text => text.Contains("UPDATE Users SET Active = $1", StringComparison.Ordinal));
+        Assert.True(sql.Length >= 8, $"expected one statement per terminal call, got {sql.Length}: {string.Join(" | ", sql)}");
+    }
+
+    [Fact]
+    public async Task AggregatesProduceSyntheticSql()
+    {
+        var source = """
+            class Repo {
+                void Run(MyDbContext db, int minId) {
+                    db.Users.Count();
+                    db.Users.Any();
+                    db.Users.All(u => u.Id > minId);
+                    db.Orders.Sum(o => o.Total);
+                    db.Orders.Min(o => o.Total);
+                    db.Orders.Max(o => o.Total);
+                    db.Orders.Average(o => o.Total);
+                }
+            }
+            """;
+
+        var sql = (await ExtractAsync(source)).Select(result => result.Sql).ToArray();
+
+        Assert.Contains(sql, text => text.Contains("SELECT COUNT(*) FROM Users", StringComparison.Ordinal));
+        Assert.Contains(sql, text => text.Contains("SELECT 1 FROM Users LIMIT 1", StringComparison.Ordinal));
+        Assert.Contains(sql, text => text.Contains("WHERE Id > $1", StringComparison.Ordinal));
+        Assert.Contains(sql, text => text.Contains("SELECT SUM(Total) FROM Orders", StringComparison.Ordinal));
+        Assert.Contains(sql, text => text.Contains("SELECT MIN(Total) FROM Orders", StringComparison.Ordinal));
+        Assert.Contains(sql, text => text.Contains("SELECT MAX(Total) FROM Orders", StringComparison.Ordinal));
+        Assert.Contains(sql, text => text.Contains("SELECT AVG(Total) FROM Orders", StringComparison.Ordinal));
+    }
+
+    private static async Task<IReadOnlyList<ExtractorResult>> ExtractAsync(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("valk-roslyn-test-");
+        try
+        {
+            var sourceFile = Path.Combine(tempDir.FullName, "input.cs");
+            await File.WriteAllTextAsync(sourceFile, source);
+
+            var project = FindExtractorProject();
+            var dotnet = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet";
+            var startInfo = new ProcessStartInfo(dotnet, $"run --project \"{project}\" -- \"{sourceFile}\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+            startInfo.Environment["DOTNET_NOLOGO"] = "1";
+            startInfo.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1";
+
+            using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("failed to start dotnet");
+            var stdout = await process.StandardOutput.ReadToEndAsync();
+            var stderr = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            Assert.True(process.ExitCode == 0, $"extractor exited {process.ExitCode}: {stderr}");
+            return JsonSerializer.Deserialize<List<ExtractorResult>>(stdout) ?? [];
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    private static string FindExtractorProject()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir is not null)
+        {
+            var direct = Path.Combine(dir.FullName, "RoslynExtractor.csproj");
+            if (File.Exists(direct))
+            {
+                return direct;
+            }
+
+            var nested = Path.Combine(dir.FullName, "internal", "scanner", "csharp", "roslynextractor", "RoslynExtractor.csproj");
+            if (File.Exists(nested))
+            {
+                return nested;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new FileNotFoundException("RoslynExtractor.csproj was not found from the test working directory.");
+    }
+
+    private sealed class ExtractorResult
+    {
+        [JsonPropertyName("line")]
+        public int Line { get; init; }
+
+        [JsonPropertyName("column")]
+        public int Column { get; init; }
+
+        [JsonPropertyName("end_line")]
+        public int EndLine { get; init; }
+
+        [JsonPropertyName("end_column")]
+        public int EndColumn { get; init; }
+
+        [JsonPropertyName("sql")]
+        public string Sql { get; init; } = string.Empty;
+    }
+}

--- a/internal/scanner/csharp/roslynextractor/RoslynExtractor.Tests/RoslynExtractor.Tests.csproj
+++ b/internal/scanner/csharp/roslynextractor/RoslynExtractor.Tests/RoslynExtractor.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/internal/scanner/csharp/roslynextractor/RoslynExtractor.csproj
+++ b/internal/scanner/csharp/roslynextractor/RoslynExtractor.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="RoslynExtractor.Tests/**/*.cs" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+  </ItemGroup>
+</Project>

--- a/internal/scanner/csharp/scanner.go
+++ b/internal/scanner/csharp/scanner.go
@@ -1,0 +1,1303 @@
+// Copyright 2025 ValkDB
+// SPDX-License-Identifier: Apache-2.0
+
+// Package csharp provides a scanner that extracts SQL from EF Core raw SQL
+// execution calls in C# source files.
+//
+// v1 covers raw EF Core SQL execution only:
+//   - ExecuteSqlRaw / ExecuteSqlRawAsync
+//   - ExecuteSqlInterpolated / ExecuteSqlInterpolatedAsync
+//
+// Query-builder, LINQ, FromSqlRaw, and SqlQueryRaw patterns are tracked
+// separately in issue #17.
+//
+// Known v1 limitations:
+//   - Variable resolution is limited to assignments that appear earlier in the
+//     enclosing method body. Cross-method, cross-file, and field/property flow
+//     are not tracked.
+//   - Only the last assignment to a given variable name before the call is
+//     captured. Conditional or branching assignments are not tracked.
+//   - Format-string normalization ({0} → $1) is applied unconditionally to
+//     ExecuteSqlRaw calls. SQL that contains literal {0} text will be rewritten.
+package csharp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"iter"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/valkdb/valk-guard/internal/scanner"
+)
+
+// Scanner extracts SQL from EF Core raw SQL execution calls in C# source files.
+type Scanner struct{}
+
+var errStop = errors.New("csharp scanner stop")
+
+// efCoreMethodNames lists the EF Core raw SQL execution methods, ordered
+// longest-first so prefix ambiguity is resolved correctly during matching.
+var efCoreMethodNames = []string{
+	"ExecuteSqlInterpolatedAsync",
+	"ExecuteSqlInterpolated",
+	"ExecuteSqlRawAsync",
+	"ExecuteSqlRaw",
+}
+
+// interpolatedMethods is the set of methods that expect interpolated strings.
+var interpolatedMethods = map[string]struct{}{
+	"ExecuteSqlInterpolated":      {},
+	"ExecuteSqlInterpolatedAsync": {},
+}
+
+// Scan walks .cs files under the given paths and streams extracted SQL statements.
+func (s *Scanner) Scan(ctx context.Context, paths []string) iter.Seq2[scanner.SQLStatement, error] {
+	return func(yield func(scanner.SQLStatement, error) bool) {
+		err := walkCSFiles(ctx, paths, func(path string, src []byte) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			content := string(src)
+			if !strings.Contains(content, "ExecuteSql") {
+				return nil
+			}
+			for _, stmt := range extractStatements(path, content) {
+				if !yield(stmt, nil) {
+					return errStop
+				}
+			}
+			return nil
+		})
+		if err != nil && !errors.Is(err, errStop) {
+			_ = yield(scanner.SQLStatement{}, err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// File walking
+// ---------------------------------------------------------------------------
+
+// walkCSFiles visits .cs inputs under paths and passes each file to fn.
+func walkCSFiles(ctx context.Context, paths []string, fn func(string, []byte) error) error {
+	for _, root := range paths {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		info, err := os.Stat(root)
+		if err != nil {
+			continue
+		}
+		if !info.IsDir() {
+			if !isCS(root) {
+				continue
+			}
+			data, err := os.ReadFile(root)
+			if err != nil {
+				return fmt.Errorf("read %s: %w", root, err)
+			}
+			if err := fn(filepath.Clean(root), data); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, we error) error {
+			if we != nil || d.IsDir() || !isCS(p) {
+				return nil
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			data, err := os.ReadFile(p)
+			if err != nil {
+				return fmt.Errorf("read %s: %w", p, err)
+			}
+			return fn(filepath.Clean(p), data)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isCS reports whether path has a .cs extension.
+func isCS(path string) bool {
+	return strings.HasSuffix(strings.ToLower(path), ".cs")
+}
+
+// ---------------------------------------------------------------------------
+// Statement extraction
+// ---------------------------------------------------------------------------
+
+// extractStatements resolves supported EF Core raw SQL calls from a source file.
+func extractStatements(path, src string) []scanner.SQLStatement {
+	lines := strings.Split(src, "\n")
+	directives := scanner.ParseDirectives(lines)
+	offsets := buildLineOffsets(src)
+	scopes := collectMethodScopes(src)
+
+	var stmts []scanner.SQLStatement
+	for _, c := range findCalls(src) {
+		scope := findMethodScope(scopes, c.dotPos)
+		if !receiverAllowed(src, c.dotPos, scope) {
+			continue
+		}
+
+		var vars map[string]varDef
+		if scope != nil {
+			vars = collectVars(src[scope.bodyStart:c.dotPos])
+		}
+
+		isInterp := isInterpolatedMethod(c.method)
+		sql, ok := parseExpr(c.firstArg, vars, isInterp, 0)
+		if !ok || sql == "" {
+			continue
+		}
+		if !isInterp {
+			sql = normalizeFormatPlaceholders(sql)
+		}
+		if !scanner.LooksLikeSQL(sql) {
+			continue
+		}
+
+		line, col := offsetToLC(offsets, c.dotPos)
+		eLine, eCol := offsetToLC(offsets, c.closePos)
+
+		stmts = append(stmts, scanner.SQLStatement{
+			SQL:       sql,
+			File:      path,
+			Line:      line,
+			Column:    col,
+			EndLine:   eLine,
+			EndColumn: eCol,
+			Engine:    scanner.EngineCSharp,
+			Disabled:  scanner.DisabledRulesForLine(directives, line),
+		})
+	}
+	return stmts
+}
+
+// isInterpolatedMethod reports whether name expects an interpolated SQL string.
+func isInterpolatedMethod(name string) bool {
+	_, ok := interpolatedMethods[name]
+	return ok
+}
+
+// ---------------------------------------------------------------------------
+// Call finding
+// ---------------------------------------------------------------------------
+
+type callSite struct {
+	dotPos   int    // position of the '.' before the method name
+	method   string // method name
+	firstArg string // raw text of the first argument
+	closePos int    // position of closing ')'
+}
+
+type methodScope struct {
+	bodyStart      int
+	bodyEnd        int
+	dbFacadeParams map[string]struct{}
+}
+
+// findCalls locates candidate ExecuteSql* call sites in source text.
+func findCalls(src string) []callSite {
+	var result []callSite
+	n := len(src)
+
+	for i := 0; i < n; {
+		if next := skipNonCode(src, i); next > i {
+			i = next
+			continue
+		}
+		if src[i] == '.' {
+			if c, next := tryMatchCall(src, i); next > 0 {
+				result = append(result, c)
+				i = next
+				continue
+			}
+		}
+		i++
+	}
+	return result
+}
+
+// tryMatchCall matches a supported ExecuteSql* invocation at dotPos.
+func tryMatchCall(src string, dotPos int) (callSite, int) {
+	n := len(src)
+	for _, method := range efCoreMethodNames {
+		end := dotPos + 1 + len(method)
+		if end > n {
+			continue
+		}
+		if src[dotPos+1:end] != method {
+			continue
+		}
+		// Ensure the match is not a prefix of a longer identifier.
+		if end < n && isIdentByte(src[end]) {
+			continue
+		}
+		// Skip whitespace to opening '('.
+		j := end
+		for j < n && isWS(src[j]) {
+			j++
+		}
+		if j >= n || src[j] != '(' {
+			continue
+		}
+		argText, closePos := extractFirstArg(src, j+1)
+		if closePos < 0 {
+			continue
+		}
+		return callSite{
+			dotPos:   dotPos,
+			method:   method,
+			firstArg: argText,
+			closePos: closePos,
+		}, closePos + 1
+	}
+	return callSite{}, 0
+}
+
+// receiverAllowed reports whether the call receiver matches a supported EF Core pattern.
+func receiverAllowed(src string, dotPos int, scope *methodScope) bool {
+	member, prev, ok := receiverMembers(src, dotPos)
+	if !ok {
+		return false
+	}
+	if member == "Database" {
+		return prev != ""
+	}
+	if scope == nil {
+		return false
+	}
+
+	names := make(map[string]struct{}, len(scope.dbFacadeParams))
+	for name := range scope.dbFacadeParams {
+		names[name] = struct{}{}
+	}
+	for name := range collectDatabaseFacadeNames(src[scope.bodyStart:dotPos]) {
+		names[name] = struct{}{}
+	}
+
+	if _, ok := names[member]; ok {
+		return true
+	}
+	return (prev == "this" || prev == "base") && hasName(names, member)
+}
+
+// receiverMembers returns the immediate receiver member and its parent member.
+func receiverMembers(src string, dotPos int) (string, string, bool) {
+	j := dotPos - 1
+	for j >= 0 && isWS(src[j]) {
+		j--
+	}
+	if j < 0 || !isIdentByte(src[j]) {
+		return "", "", false
+	}
+	end := j + 1
+	for j >= 0 && isIdentByte(src[j]) {
+		j--
+	}
+	member := src[j+1 : end]
+
+	k := j
+	for k >= 0 && isWS(src[k]) {
+		k--
+	}
+	if k < 0 || src[k] != '.' {
+		return member, "", true
+	}
+	k--
+	for k >= 0 && isWS(src[k]) {
+		k--
+	}
+	if k < 0 || !isIdentByte(src[k]) {
+		return member, "", true
+	}
+	prevEnd := k + 1
+	for k >= 0 && isIdentByte(src[k]) {
+		k--
+	}
+	return member, src[k+1 : prevEnd], true
+}
+
+// extractFirstArg extracts the raw text of the first argument from a call.
+// pos is the position after '('. Returns (argText, closeParenPos).
+func extractFirstArg(src string, pos int) (string, int) {
+	n := len(src)
+	depth := 1
+
+	start := pos
+	for start < n && isWS(src[start]) {
+		start++
+	}
+	argEnd := -1
+
+	for i := start; i < n; {
+		if next := skipNonCode(src, i); next > i {
+			i = next
+			continue
+		}
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				if argEnd < 0 {
+					argEnd = i
+				}
+				return strings.TrimSpace(src[start:argEnd]), i
+			}
+		case ',':
+			if depth == 1 && argEnd < 0 {
+				argEnd = i
+			}
+		}
+		i++
+	}
+	return "", -1
+}
+
+// collectMethodScopes finds method-like bodies and the DatabaseFacade params they declare.
+func collectMethodScopes(src string) []methodScope {
+	var scopes []methodScope
+	for i := 0; i < len(src); i++ {
+		if next := skipNonCode(src, i); next > i {
+			i = next - 1
+			continue
+		}
+		if src[i] != '{' {
+			continue
+		}
+		closeParen := prevNonWS(src, i-1)
+		if closeParen < 0 || src[closeParen] != ')' {
+			continue
+		}
+		openParen := findMatchingOpenParen(src, closeParen)
+		if openParen < 0 {
+			continue
+		}
+		name := identBeforePos(src, openParen)
+		if name == "" || isMethodBlockKeyword(name) {
+			continue
+		}
+		closeBrace := findMatchingCloseBrace(src, i)
+		if closeBrace < 0 {
+			continue
+		}
+		scopes = append(scopes, methodScope{
+			bodyStart:      i + 1,
+			bodyEnd:        closeBrace,
+			dbFacadeParams: collectDatabaseFacadeNames(src[openParen+1 : closeParen]),
+		})
+	}
+	return scopes
+}
+
+// findMethodScope returns the innermost method scope containing pos.
+func findMethodScope(scopes []methodScope, pos int) *methodScope {
+	var best *methodScope
+	bestLen := 0
+	for i := range scopes {
+		scope := &scopes[i]
+		if pos < scope.bodyStart || pos > scope.bodyEnd {
+			continue
+		}
+		length := scope.bodyEnd - scope.bodyStart
+		if best == nil || length < bestLen {
+			best = scope
+			bestLen = length
+		}
+	}
+	return best
+}
+
+// findMatchingOpenParen returns the matching '(' for a ')' at closePos.
+func findMatchingOpenParen(src string, closePos int) int {
+	depth := 0
+	for i := closePos; i >= 0; i-- {
+		switch src[i] {
+		case ')':
+			depth++
+		case '(':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// findMatchingCloseBrace returns the matching '}' for a '{' at openPos.
+func findMatchingCloseBrace(src string, openPos int) int {
+	depth := 0
+	for i := openPos; i < len(src); i++ {
+		if next := skipNonCode(src, i); next > i {
+			i = next - 1
+			continue
+		}
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+var methodBlockKeywords = map[string]struct{}{
+	"if": {}, "for": {}, "foreach": {}, "while": {}, "switch": {},
+	"catch": {}, "using": {}, "lock": {}, "checked": {}, "unchecked": {},
+}
+
+// isMethodBlockKeyword reports whether name begins a control-flow block, not a method.
+func isMethodBlockKeyword(name string) bool {
+	_, ok := methodBlockKeywords[name]
+	return ok
+}
+
+// ---------------------------------------------------------------------------
+// SQL resolution
+// ---------------------------------------------------------------------------
+
+type varDef struct {
+	expr string // raw RHS expression text
+}
+
+// parseExpr tries to resolve a C# expression to SQL text.
+// It handles string literals, variable references, and simple concatenation.
+func parseExpr(expr string, vars map[string]varDef, isInterp bool, depth int) (string, bool) {
+	if depth > 5 {
+		return "", false
+	}
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return "", false
+	}
+
+	var result strings.Builder
+	remaining := expr
+
+	for remaining != "" {
+		remaining = strings.TrimSpace(remaining)
+		if remaining == "" {
+			break
+		}
+
+		// Try string literal.
+		if content, rest, ok := tryParseStringLiteral(remaining); ok {
+			result.WriteString(content)
+			remaining = strings.TrimSpace(rest)
+			if strings.HasPrefix(remaining, "+") {
+				remaining = strings.TrimSpace(remaining[1:])
+				continue
+			}
+			if remaining == "" {
+				return result.String(), true
+			}
+			return "", false
+		}
+
+		// Try identifier (variable reference).
+		name := readIdent(remaining)
+		if name != "" {
+			rest := strings.TrimSpace(remaining[len(name):])
+			if v, ok := vars[name]; ok {
+				resolved, rok := parseExpr(v.expr, vars, isInterp, depth+1)
+				if !rok {
+					return "", false
+				}
+				result.WriteString(resolved)
+				remaining = rest
+				if strings.HasPrefix(remaining, "+") {
+					remaining = strings.TrimSpace(remaining[1:])
+					continue
+				}
+				if remaining == "" {
+					return result.String(), true
+				}
+				return "", false
+			}
+			return "", false // unresolved variable
+		}
+
+		return "", false // unrecognized expression
+	}
+
+	if result.Len() == 0 {
+		return "", false
+	}
+	return result.String(), true
+}
+
+// tryParseStringLiteral attempts to parse a C# string literal from the start
+// of s. Returns (content, rest, ok). The content has interpolation expressions
+// replaced with $1, $2 placeholders and escape sequences decoded.
+func tryParseStringLiteral(s string) (string, string, bool) {
+	// $@"..." or @$"..." (verbatim interpolated)
+	if strings.HasPrefix(s, `$@"`) || strings.HasPrefix(s, `@$"`) {
+		content, rest := readVerbInterpStr(s[3:])
+		return content, rest, true
+	}
+	// $"""...""" (raw interpolated)
+	if len(s) >= 4 && s[0] == '$' && s[1] == '"' && s[2] == '"' && s[3] == '"' {
+		content, rest := readRawInterpStr(s[4:])
+		return content, rest, true
+	}
+	// $"..." (interpolated)
+	if len(s) >= 2 && s[0] == '$' && s[1] == '"' {
+		content, rest := readInterpStr(s[2:])
+		return content, rest, true
+	}
+	// @"..." (verbatim)
+	if len(s) >= 2 && s[0] == '@' && s[1] == '"' {
+		content, rest := readVerbStr(s[2:])
+		return content, rest, true
+	}
+	// """...""" (raw)
+	if len(s) >= 6 && s[0] == '"' && s[1] == '"' && s[2] == '"' {
+		content, rest := readRawStr(s[3:])
+		return content, rest, true
+	}
+	// "..." (regular)
+	if len(s) >= 1 && s[0] == '"' {
+		content, rest := readRegStr(s[1:])
+		return content, rest, true
+	}
+	return "", s, false
+}
+
+// ---------------------------------------------------------------------------
+// String content reading — each function starts after the opening delimiter
+// and returns (content, rest) where rest is the text after the closing delimiter.
+// ---------------------------------------------------------------------------
+
+// readRegStr reads a regular C# string ("...") starting after the opening ".
+func readRegStr(s string) (string, string) {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			if i+1 < len(s) {
+				i++
+				switch s[i] {
+				case 'n':
+					b.WriteByte('\n')
+				case 'r':
+					b.WriteByte('\r')
+				case 't':
+					b.WriteByte('\t')
+				case '\\':
+					b.WriteByte('\\')
+				case '"':
+					b.WriteByte('"')
+				case '0':
+					b.WriteByte(0)
+				default:
+					b.WriteByte('\\')
+					b.WriteByte(s[i])
+				}
+			}
+		case '"':
+			return b.String(), strings.TrimSpace(s[i+1:])
+		default:
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String(), ""
+}
+
+// readVerbStr reads a verbatim C# string (@"...") starting after @".
+func readVerbStr(s string) (string, string) {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '"' {
+			if i+1 < len(s) && s[i+1] == '"' {
+				b.WriteByte('"')
+				i++
+				continue
+			}
+			return b.String(), strings.TrimSpace(s[i+1:])
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String(), ""
+}
+
+// readRawStr reads a raw C# string ("""...""") starting after the opening """.
+func readRawStr(s string) (string, string) {
+	for i := 0; i+2 < len(s); i++ {
+		if s[i] == '"' && s[i+1] == '"' && s[i+2] == '"' {
+			return trimRawContent(s[:i]), strings.TrimSpace(s[i+3:])
+		}
+	}
+	return trimRawContent(s), ""
+}
+
+// readInterpStr reads an interpolated C# string ($"...") starting after $".
+// Replaces {expr} with $1, $2, etc.
+func readInterpStr(s string) (string, string) {
+	var b strings.Builder
+	ph := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			if i+1 < len(s) {
+				i++
+				switch s[i] {
+				case 'n':
+					b.WriteByte('\n')
+				case 'r':
+					b.WriteByte('\r')
+				case 't':
+					b.WriteByte('\t')
+				case '\\':
+					b.WriteByte('\\')
+				case '"':
+					b.WriteByte('"')
+				case '0':
+					b.WriteByte(0)
+				default:
+					b.WriteByte('\\')
+					b.WriteByte(s[i])
+				}
+			}
+		case '{':
+			if i+1 < len(s) && s[i+1] == '{' {
+				b.WriteByte('{')
+				i++
+				continue
+			}
+			end := findCloseBrace(s, i+1)
+			ph++
+			fmt.Fprintf(&b, "$%d", ph)
+			i = end
+		case '}':
+			if i+1 < len(s) && s[i+1] == '}' {
+				b.WriteByte('}')
+				i++
+				continue
+			}
+			b.WriteByte('}')
+		case '"':
+			return b.String(), strings.TrimSpace(s[i+1:])
+		default:
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String(), ""
+}
+
+// readVerbInterpStr reads a verbatim interpolated string ($@"..." or @$"...").
+func readVerbInterpStr(s string) (string, string) {
+	var b strings.Builder
+	ph := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			if i+1 < len(s) && s[i+1] == '{' {
+				b.WriteByte('{')
+				i++
+				continue
+			}
+			end := findCloseBrace(s, i+1)
+			ph++
+			fmt.Fprintf(&b, "$%d", ph)
+			i = end
+		case '}':
+			if i+1 < len(s) && s[i+1] == '}' {
+				b.WriteByte('}')
+				i++
+				continue
+			}
+			b.WriteByte('}')
+		case '"':
+			if i+1 < len(s) && s[i+1] == '"' {
+				b.WriteByte('"')
+				i++
+				continue
+			}
+			return b.String(), strings.TrimSpace(s[i+1:])
+		default:
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String(), ""
+}
+
+// readRawInterpStr reads a raw interpolated string ($"""...""").
+func readRawInterpStr(s string) (string, string) {
+	var b strings.Builder
+	ph := 0
+	for i := 0; i < len(s); i++ {
+		if i+2 < len(s) && s[i] == '"' && s[i+1] == '"' && s[i+2] == '"' {
+			return trimRawContent(b.String()), strings.TrimSpace(s[i+3:])
+		}
+		switch s[i] {
+		case '{':
+			if i+1 < len(s) && s[i+1] == '{' {
+				b.WriteByte('{')
+				i++
+				continue
+			}
+			end := findCloseBrace(s, i+1)
+			ph++
+			fmt.Fprintf(&b, "$%d", ph)
+			i = end
+		case '}':
+			if i+1 < len(s) && s[i+1] == '}' {
+				b.WriteByte('}')
+				i++
+				continue
+			}
+			b.WriteByte('}')
+		default:
+			b.WriteByte(s[i])
+		}
+	}
+	return trimRawContent(b.String()), ""
+}
+
+// findCloseBrace finds the matching } for an interpolation expression.
+// It handles all C# string literal types (regular, verbatim, raw,
+// interpolated) inside the expression by reusing skipStringLit.
+func findCloseBrace(s string, pos int) int {
+	depth := 1
+	for i := pos; i < len(s) && depth > 0; {
+		// Skip any string/char literal that starts at i.
+		if next := skipStringLit(s, i); next > i {
+			i = next
+			continue
+		}
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+		i++
+	}
+	return len(s) - 1
+}
+
+// trimRawContent strips the required leading/trailing newlines from raw string content.
+func trimRawContent(s string) string {
+	if strings.HasPrefix(s, "\r\n") {
+		s = s[2:]
+	} else if strings.HasPrefix(s, "\n") {
+		s = s[1:]
+	}
+	if strings.HasSuffix(s, "\r\n") {
+		s = s[:len(s)-2]
+	} else if strings.HasSuffix(s, "\n") {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// Code region skipping — used to identify code vs non-code (comments/strings)
+// ---------------------------------------------------------------------------
+
+// skipNonCode skips past comments, strings, and char literals at position i.
+// Returns the position after the skipped element, or i if nothing to skip.
+func skipNonCode(src string, i int) int {
+	n := len(src)
+	// Line comment
+	if i+1 < n && src[i] == '/' && src[i+1] == '/' {
+		j := i + 2
+		for j < n && src[j] != '\n' {
+			j++
+		}
+		if j < n {
+			j++
+		}
+		return j
+	}
+	// Block comment
+	if i+1 < n && src[i] == '/' && src[i+1] == '*' {
+		j := i + 2
+		for j+1 < n {
+			if src[j] == '*' && src[j+1] == '/' {
+				return j + 2
+			}
+			j++
+		}
+		return n
+	}
+	return skipStringLit(src, i)
+}
+
+// skipStringLit checks if position i starts a string or char literal.
+func skipStringLit(src string, i int) int {
+	n := len(src)
+	// $@"..." or @$"..."
+	if i+2 < n &&
+		((src[i] == '$' && src[i+1] == '@' && src[i+2] == '"') ||
+			(src[i] == '@' && src[i+1] == '$' && src[i+2] == '"')) {
+		return skipVerbInterpStrLit(src, i+3)
+	}
+	// $"""..."""
+	if i+3 < n && src[i] == '$' && src[i+1] == '"' && src[i+2] == '"' && src[i+3] == '"' {
+		return skipRawStrLit(src, i+4)
+	}
+	// $"..."
+	if i+1 < n && src[i] == '$' && src[i+1] == '"' {
+		return skipInterpStrLit(src, i+2)
+	}
+	// @"..."
+	if i+1 < n && src[i] == '@' && src[i+1] == '"' {
+		return skipVerbStrLit(src, i+2)
+	}
+	// """..."""
+	if i+2 < n && src[i] == '"' && src[i+1] == '"' && src[i+2] == '"' {
+		return skipRawStrLit(src, i+3)
+	}
+	// "..."
+	if i < n && src[i] == '"' {
+		return skipRegStrLit(src, i+1)
+	}
+	// '...'
+	if i < n && src[i] == '\'' {
+		return skipCharLit(src, i+1)
+	}
+	return i
+}
+
+// skipRegStrLit skips a regular string literal and returns the next position.
+func skipRegStrLit(src string, pos int) int {
+	for i := pos; i < len(src); i++ {
+		if src[i] == '\\' {
+			i++
+			continue
+		}
+		if src[i] == '"' {
+			return i + 1
+		}
+	}
+	return len(src)
+}
+
+// skipVerbStrLit skips a verbatim string literal and returns the next position.
+func skipVerbStrLit(src string, pos int) int {
+	for i := pos; i < len(src); i++ {
+		if src[i] == '"' {
+			if i+1 < len(src) && src[i+1] == '"' {
+				i++
+				continue
+			}
+			return i + 1
+		}
+	}
+	return len(src)
+}
+
+// skipInterpStrLit skips an interpolated string literal and returns the next position.
+func skipInterpStrLit(src string, pos int) int {
+	for i := pos; i < len(src); i++ {
+		switch src[i] {
+		case '\\':
+			i++
+		case '{':
+			if i+1 < len(src) && src[i+1] == '{' {
+				i++
+				continue
+			}
+			i = skipBraceExprLit(src, i+1) - 1
+		case '"':
+			return i + 1
+		}
+	}
+	return len(src)
+}
+
+// skipVerbInterpStrLit skips a verbatim interpolated string literal.
+func skipVerbInterpStrLit(src string, pos int) int {
+	for i := pos; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			if i+1 < len(src) && src[i+1] == '{' {
+				i++
+				continue
+			}
+			i = skipBraceExprLit(src, i+1) - 1
+		case '"':
+			if i+1 < len(src) && src[i+1] == '"' {
+				i++
+				continue
+			}
+			return i + 1
+		}
+	}
+	return len(src)
+}
+
+// skipRawStrLit skips a raw string literal and returns the next position.
+func skipRawStrLit(src string, pos int) int {
+	for i := pos; i+2 < len(src); i++ {
+		if src[i] == '"' && src[i+1] == '"' && src[i+2] == '"' {
+			return i + 3
+		}
+	}
+	return len(src)
+}
+
+// skipCharLit skips a character literal and returns the next position.
+func skipCharLit(src string, pos int) int {
+	for i := pos; i < len(src); i++ {
+		if src[i] == '\\' {
+			i++
+			continue
+		}
+		if src[i] == '\'' {
+			return i + 1
+		}
+	}
+	return len(src)
+}
+
+// skipBraceExprLit skips an interpolated brace expression and returns the next position.
+func skipBraceExprLit(src string, pos int) int {
+	depth := 1
+	for i := pos; i < len(src) && depth > 0; i++ {
+		if next := skipStringLit(src, i); next > i {
+			i = next - 1
+			continue
+		}
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return len(src)
+}
+
+// ---------------------------------------------------------------------------
+// Variable collection
+// ---------------------------------------------------------------------------
+
+// collectVars gathers simple string-backed variable assignments from src.
+func collectVars(src string) map[string]varDef {
+	vars := make(map[string]varDef)
+	n := len(src)
+
+	for i := 0; i < n; {
+		if next := skipNonCode(src, i); next > i {
+			i = next
+			continue
+		}
+		if src[i] == '=' && !isCompoundOrComparison(src, i, n) {
+			name := identBefore(src, i)
+			if name == "" || isCSharpKeyword(name) {
+				i++
+				continue
+			}
+			rhsStart := i + 1
+			for rhsStart < n && isWS(src[rhsStart]) {
+				rhsStart++
+			}
+			rhsEnd := findSemicolon(src, rhsStart)
+			if rhsEnd < 0 {
+				i++
+				continue
+			}
+			rhs := strings.TrimSpace(src[rhsStart:rhsEnd])
+			if rhs != "" && isStringLiteralStart(rhs) {
+				vars[name] = varDef{expr: rhs}
+			}
+			i = rhsEnd + 1
+			continue
+		}
+		i++
+	}
+	return vars
+}
+
+// collectDatabaseFacadeNames extracts identifiers declared with DatabaseFacade type text.
+func collectDatabaseFacadeNames(src string) map[string]struct{} {
+	names := make(map[string]struct{})
+	n := len(src)
+
+	for i := 0; i < n; {
+		if next := skipNonCode(src, i); next > i {
+			i = next
+			continue
+		}
+		typeLen := matchDatabaseFacadeType(src, i)
+		if typeLen == 0 {
+			i++
+			continue
+		}
+
+		j := i + typeLen
+		for j < n && isWS(src[j]) {
+			j++
+		}
+		if j < n && src[j] == '?' {
+			j++
+			for j < n && isWS(src[j]) {
+				j++
+			}
+		}
+
+		name := readIdent(src[j:])
+		if name != "" && !isCSharpKeyword(name) {
+			names[name] = struct{}{}
+			i = j + len(name)
+			continue
+		}
+		i++
+	}
+
+	return names
+}
+
+// matchDatabaseFacadeType reports the length of a DatabaseFacade type token at pos.
+func matchDatabaseFacadeType(src string, pos int) int {
+	candidates := []string{
+		"Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade",
+		"DatabaseFacade",
+	}
+	for _, candidate := range candidates {
+		end := pos + len(candidate)
+		if end > len(src) || src[pos:end] != candidate {
+			continue
+		}
+		if pos > 0 && (isIdentByte(src[pos-1]) || src[pos-1] == '.') {
+			continue
+		}
+		if end < len(src) && (isIdentByte(src[end]) || src[end] == '.') {
+			continue
+		}
+		return len(candidate)
+	}
+	return 0
+}
+
+// isCompoundOrComparison reports whether '=' at i belongs to a non-assignment operator.
+func isCompoundOrComparison(src string, i, n int) bool {
+	if i+1 < n && (src[i+1] == '=' || src[i+1] == '>') {
+		return true
+	}
+	if i > 0 {
+		p := src[i-1]
+		if p == '!' || p == '<' || p == '>' || p == '=' ||
+			p == '+' || p == '-' || p == '*' || p == '/' ||
+			p == '%' || p == '&' || p == '|' || p == '^' || p == '?' {
+			return true
+		}
+	}
+	return false
+}
+
+// identBefore returns the identifier immediately before pos, excluding member assignments.
+func identBefore(src string, pos int) string {
+	j := pos - 1
+	for j >= 0 && (src[j] == ' ' || src[j] == '\t') {
+		j--
+	}
+	if j < 0 || !isIdentByte(src[j]) {
+		return ""
+	}
+	end := j + 1
+	for j >= 0 && isIdentByte(src[j]) {
+		j--
+	}
+	name := src[j+1 : end]
+	// Reject member/property assignments like obj.Query = "..." — the dot
+	// means this is not a local variable declaration.
+	if j >= 0 && src[j] == '.' {
+		return ""
+	}
+	return name
+}
+
+// identBeforePos returns the identifier immediately preceding pos.
+func identBeforePos(src string, pos int) string {
+	j := prevNonWS(src, pos-1)
+	if j < 0 || !isIdentByte(src[j]) {
+		return ""
+	}
+	end := j + 1
+	for j >= 0 && isIdentByte(src[j]) {
+		j--
+	}
+	return src[j+1 : end]
+}
+
+// findSemicolon returns the next statement terminator starting from pos.
+func findSemicolon(src string, pos int) int {
+	for i := pos; i < len(src); {
+		if next := skipNonCode(src, i); next > i {
+			i = next
+			continue
+		}
+		if src[i] == ';' {
+			return i
+		}
+		if src[i] == '{' || src[i] == '}' {
+			return -1
+		}
+		i++
+	}
+	return -1
+}
+
+// isStringLiteralStart reports whether s begins with a supported C# string literal.
+func isStringLiteralStart(s string) bool {
+	if s == "" {
+		return false
+	}
+	switch s[0] {
+	case '"':
+		return true
+	case '@':
+		return len(s) > 1 && (s[1] == '"' || (s[1] == '$' && len(s) > 2 && s[2] == '"'))
+	case '$':
+		return len(s) > 1 && (s[1] == '"' || (s[1] == '@' && len(s) > 2 && s[2] == '"'))
+	}
+	return false
+}
+
+var csharpKeywords = map[string]struct{}{
+	"if": {}, "else": {}, "for": {}, "foreach": {}, "while": {},
+	"do": {}, "switch": {}, "case": {}, "break": {}, "continue": {},
+	"return": {}, "new": {}, "null": {}, "true": {}, "false": {},
+	"this": {}, "base": {}, "class": {}, "struct": {}, "interface": {},
+	"void": {}, "typeof": {}, "sizeof": {}, "nameof": {},
+	"throw": {}, "try": {}, "catch": {}, "finally": {},
+	"lock": {}, "using": {}, "checked": {}, "unchecked": {},
+	"default": {}, "delegate": {}, "event": {}, "fixed": {},
+	"goto": {}, "implicit": {}, "explicit": {}, "extern": {},
+	"operator": {}, "params": {}, "ref": {}, "out": {},
+	"stackalloc": {}, "unsafe": {}, "volatile": {},
+}
+
+// isCSharpKeyword reports whether s is a reserved C# keyword used for filtering.
+func isCSharpKeyword(s string) bool {
+	_, ok := csharpKeywords[s]
+	return ok
+}
+
+// hasName reports whether name exists in the identifier set.
+func hasName(names map[string]struct{}, name string) bool {
+	_, ok := names[name]
+	return ok
+}
+
+// ---------------------------------------------------------------------------
+// Placeholder normalization
+// ---------------------------------------------------------------------------
+
+// normalizeFormatPlaceholders converts .NET format string placeholders ({0},
+// {1}, ...) to PostgreSQL-style placeholders ($1, $2, ...).
+func normalizeFormatPlaceholders(sql string) string {
+	var b strings.Builder
+	changed := false
+	for i := 0; i < len(sql); i++ {
+		if sql[i] == '{' {
+			j := i + 1
+			for j < len(sql) && sql[j] >= '0' && sql[j] <= '9' {
+				j++
+			}
+			if j > i+1 && j < len(sql) && sql[j] == '}' {
+				num := 0
+				for k := i + 1; k < j; k++ {
+					num = num*10 + int(sql[k]-'0')
+				}
+				fmt.Fprintf(&b, "$%d", num+1)
+				i = j
+				changed = true
+				continue
+			}
+		}
+		b.WriteByte(sql[i])
+	}
+	if !changed {
+		return sql
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
+// buildLineOffsets builds a line-start offset table for source positions.
+func buildLineOffsets(src string) []int {
+	offsets := []int{0}
+	for i := 0; i < len(src); i++ {
+		if src[i] == '\n' {
+			offsets = append(offsets, i+1)
+		}
+	}
+	return offsets
+}
+
+// offsetToLC converts a byte offset into 1-based line and column coordinates.
+func offsetToLC(offsets []int, pos int) (int, int) {
+	lo, hi := 0, len(offsets)-1
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if offsets[mid] <= pos {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return lo + 1, pos - offsets[lo] + 1
+}
+
+// prevNonWS returns the previous non-whitespace byte index before or at pos.
+func prevNonWS(src string, pos int) int {
+	for pos >= 0 && isWS(src[pos]) {
+		pos--
+	}
+	return pos
+}
+
+// isIdentByte reports whether c is valid in a C# identifier tail.
+func isIdentByte(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') || c == '_'
+}
+
+// readIdent reads the leading C# identifier from s.
+func readIdent(s string) string {
+	if s == "" {
+		return ""
+	}
+	c := s[0]
+	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_') {
+		return ""
+	}
+	i := 1
+	for i < len(s) && isIdentByte(s[i]) {
+		i++
+	}
+	return s[:i]
+}
+
+// isWS reports whether c is recognized as scanner whitespace.
+func isWS(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}

--- a/internal/scanner/csharp/scanner.go
+++ b/internal/scanner/csharp/scanner.go
@@ -1,125 +1,166 @@
 // Copyright 2025 ValkDB
 // SPDX-License-Identifier: Apache-2.0
 
-// Package csharp provides a scanner that extracts SQL from EF Core raw SQL
-// execution calls in C# source files.
+// Package csharp provides an EF Core scanner for C# source files.
 //
-// v1 covers raw EF Core SQL execution only:
-//   - ExecuteSqlRaw / ExecuteSqlRawAsync
-//   - ExecuteSqlInterpolated / ExecuteSqlInterpolatedAsync
-//
-// Query-builder, LINQ, FromSqlRaw, and SqlQueryRaw patterns are tracked
-// separately in issue #17.
-//
-// Known v1 limitations:
-//   - Variable resolution is limited to assignments that appear earlier in the
-//     enclosing method body. Cross-method, cross-file, and field/property flow
-//     are not tracked.
-//   - Only the last assignment to a given variable name before the call is
-//     captured. Conditional or branching assignments are not tracked.
-//   - Format-string normalization ({0} → $1) is applied unconditionally to
-//     ExecuteSqlRaw calls. SQL that contains literal {0} text will be rewritten.
+// The scanner intentionally avoids Go-side string heuristics for C# code
+// constructs. It sends readable .cs files to the embedded Roslyn extractor,
+// which parses real C# syntax and decides whether raw EF Core SQL or
+// deterministic DbSet/LINQ query chains are present. Extracted and synthetic
+// SQL then flows through the normal Valk Guard SQL parser and rule engine.
 package csharp
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
 	"iter"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/valkdb/valk-guard/internal/scanner"
 )
 
-// Scanner extracts SQL from EF Core raw SQL execution calls in C# source files.
-type Scanner struct{}
+//go:embed roslynextractor/RoslynExtractor.csproj roslynextractor/Program.cs
+var roslynProject embed.FS
 
-var errStop = errors.New("csharp scanner stop")
+const (
+	csprojEmbedPath       = "roslynextractor/RoslynExtractor.csproj"
+	programEmbedPath      = "roslynextractor/Program.cs"
+	extractorTimeout      = 5 * time.Minute
+	missingDotnetErrorMsg = ".NET SDK is required for scanning C# EF Core files"
+)
 
-// efCoreMethodNames lists the EF Core raw SQL execution methods, ordered
-// longest-first so prefix ambiguity is resolved correctly during matching.
-var efCoreMethodNames = []string{
-	"ExecuteSqlInterpolatedAsync",
-	"ExecuteSqlInterpolated",
-	"ExecuteSqlRawAsync",
-	"ExecuteSqlRaw",
+var (
+	roslynBuildMu sync.Mutex
+	userCacheDir  = os.UserCacheDir
+)
+
+// Scanner extracts raw and synthetic SQL from EF Core usage in C# source files.
+type Scanner struct {
+	// DotnetPath optionally overrides the dotnet executable used to run the
+	// embedded Roslyn extractor. Empty means PATH lookup for "dotnet".
+	DotnetPath string
+	// ProjectPath optionally points at a RoslynExtractor.csproj on disk. Empty
+	// means the embedded extractor project is materialized and reused from the
+	// user cache directory.
+	ProjectPath string
+	// Timeout optionally overrides the Roslyn extractor timeout. Empty uses the
+	// package default. Tests use this to exercise timeout handling quickly.
+	Timeout time.Duration
 }
 
-// interpolatedMethods is the set of methods that expect interpolated strings.
-var interpolatedMethods = map[string]struct{}{
-	"ExecuteSqlInterpolated":      {},
-	"ExecuteSqlInterpolatedAsync": {},
-}
-
-// Scan walks .cs files under the given paths and streams extracted SQL statements.
+// Scan walks the given paths, sends readable C# files to the Roslyn AST
+// extractor, and streams extracted SQL statements. The .NET SDK is only
+// required when at least one .cs file is present and the C# source is enabled.
 func (s *Scanner) Scan(ctx context.Context, paths []string) iter.Seq2[scanner.SQLStatement, error] {
 	return func(yield func(scanner.SQLStatement, error) bool) {
-		err := walkCSFiles(ctx, paths, func(path string, src []byte) error {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			content := string(src)
-			if !strings.Contains(content, "ExecuteSql") {
-				return nil
-			}
-			for _, stmt := range extractStatements(path, content) {
-				if !yield(stmt, nil) {
-					return errStop
-				}
-			}
-			return nil
-		})
-		if err != nil && !errors.Is(err, errStop) {
+		candidates, err := collectCandidates(ctx, paths)
+		if err != nil {
 			_ = yield(scanner.SQLStatement{}, err)
+			return
 		}
+		if len(candidates) == 0 {
+			return
+		}
+
+		extracted, err := s.runRoslynExtractor(ctx, candidates)
+		if err != nil {
+			_ = yield(scanner.SQLStatement{}, err)
+			return
+		}
+
+		yieldWithDirectives(ctx, extracted, yield)
 	}
 }
 
-// ---------------------------------------------------------------------------
-// File walking
-// ---------------------------------------------------------------------------
+// csResult represents one SQL statement emitted by the Roslyn extractor.
+type csResult struct {
+	File      string `json:"file"`
+	Line      int    `json:"line"`
+	Column    int    `json:"column"`
+	EndLine   int    `json:"end_line"`
+	EndColumn int    `json:"end_column"`
+	SQL       string `json:"sql"`
+}
 
-// walkCSFiles visits .cs inputs under paths and passes each file to fn.
+// collectCandidates returns readable .cs files under paths. Candidate
+// classification happens inside Roslyn so scanner logic does not depend on
+// substring checks over source text.
+func collectCandidates(ctx context.Context, paths []string) ([]string, error) {
+	var candidates []string
+	seen := make(map[string]struct{})
+
+	err := walkCSFiles(ctx, paths, func(path string, _ []byte) error {
+		clean := filepath.Clean(path)
+		if _, exists := seen[clean]; exists {
+			return nil
+		}
+		seen[clean] = struct{}{}
+		candidates = append(candidates, clean)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return candidates, nil
+}
+
+// walkCSFiles visits every readable .cs file under paths and passes its content
+// to fn. Missing roots are ignored to match the existing scanner behavior.
 func walkCSFiles(ctx context.Context, paths []string, fn func(string, []byte) error) error {
 	for _, root := range paths {
-		if ctx.Err() != nil {
-			return ctx.Err()
+		if err := ctx.Err(); err != nil {
+			return err
 		}
+
 		info, err := os.Stat(root)
 		if err != nil {
 			continue
 		}
 		if !info.IsDir() {
-			if !isCS(root) {
+			if !isCSharpSource(root) {
 				continue
 			}
-			data, err := os.ReadFile(root) //nolint:gosec // scanning user-provided source paths
-			if err != nil {
-				return fmt.Errorf("read %s: %w", root, err)
+			data, readErr := os.ReadFile(root) //nolint:gosec // scanner input is user-selected source code
+			if readErr != nil {
+				return fmt.Errorf("read C# file %s: %w", root, readErr)
 			}
-			if err := fn(filepath.Clean(root), data); err != nil {
+			if err := fn(root, data); err != nil {
 				return err
 			}
 			continue
 		}
-		if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, we error) error {
-			if we != nil {
-				return we
+
+		if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
 			}
-			if d.IsDir() || !isCS(p) {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if d.IsDir() {
 				return nil
 			}
-			if ctx.Err() != nil {
-				return ctx.Err()
+			if !isCSharpSource(path) {
+				return nil
 			}
-			data, err := os.ReadFile(p) //nolint:gosec // scanning user-provided source paths
-			if err != nil {
-				return fmt.Errorf("read %s: %w", p, err)
+			data, readErr := os.ReadFile(path) //nolint:gosec // scanner input is user-selected source code
+			if readErr != nil {
+				return fmt.Errorf("read C# file %s: %w", path, readErr)
 			}
-			return fn(filepath.Clean(p), data)
+			return fn(path, data)
 		}); err != nil {
 			return err
 		}
@@ -127,1181 +168,383 @@ func walkCSFiles(ctx context.Context, paths []string, fn func(string, []byte) er
 	return nil
 }
 
-// isCS reports whether path has a .cs extension.
-func isCS(path string) bool {
-	return strings.HasSuffix(strings.ToLower(path), ".cs")
+// isCSharpSource reports whether path has a .cs extension.
+func isCSharpSource(path string) bool {
+	return strings.EqualFold(filepath.Ext(path), ".cs")
 }
 
-// ---------------------------------------------------------------------------
-// Statement extraction
-// ---------------------------------------------------------------------------
+// runRoslynExtractor runs the Roslyn extractor and decodes the JSON statement
+// stream. The embedded project is cached and published once per content hash;
+// explicit ProjectPath overrides keep direct dotnet run behavior for tests and
+// local extractor development.
+func (s *Scanner) runRoslynExtractor(parent context.Context, files []string) ([]csResult, error) {
+	project, err := s.roslynProject()
+	if err != nil {
+		return nil, err
+	}
+	defer project.cleanup()
 
-// extractStatements resolves supported EF Core raw SQL calls from a source file.
-func extractStatements(path, src string) []scanner.SQLStatement {
-	lines := strings.Split(src, "\n")
-	directives := scanner.ParseDirectives(lines)
-	offsets := buildLineOffsets(src)
-	scopes := collectMethodScopes(src)
-	calls := findCalls(src)
+	timeout := s.Timeout
+	if timeout <= 0 {
+		timeout = extractorTimeout
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
 
-	stmts := make([]scanner.SQLStatement, 0, len(calls))
-	for _, c := range calls {
-		scope := findMethodScope(scopes, c.dotPos)
-		if !receiverAllowed(src, c.dotPos, scope) {
+	if project.cached {
+		if _, err := os.Stat(project.executablePath); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("stat cached C# Roslyn extractor binary: %w", err)
+			}
+			dotnet, err := s.dotnetExecutable()
+			if err != nil {
+				return nil, err
+			}
+			if err := ensureCachedRoslynExtractorPublished(ctx, dotnet, project.projectPath, project.executablePath); err != nil {
+				return nil, err
+			}
+		}
+		return runRoslynBinary(ctx, project.executablePath, files, timeout)
+	}
+
+	dotnet, err := s.dotnetExecutable()
+	if err != nil {
+		return nil, err
+	}
+	return runRoslynProject(ctx, dotnet, project.projectPath, files, timeout)
+}
+
+// runRoslynProject executes an explicit extractor project with dotnet run.
+func runRoslynProject(ctx context.Context, dotnet, projectPath string, files []string, timeout time.Duration) ([]csResult, error) {
+	args := make([]string, 0, 4+len(files))
+	args = append(args, "run", "--project", projectPath, "--")
+	args = append(args, files...)
+	//nolint:gosec // dotnet is a resolved SDK executable and args point at scanner-selected source files.
+	//nolint:gosec // dotnet is a resolved SDK executable used to publish scanner-owned embedded code.
+	//nolint:gosec // dotnet is a resolved SDK executable used to publish scanner-owned embedded code.
+	cmd := exec.CommandContext(ctx, dotnet, args...)
+	cmd.Env = dotnetEnv()
+	return decodeRoslynCommand(cmd, ctx, timeout)
+}
+
+// runRoslynBinary executes the cached published extractor binary.
+func runRoslynBinary(ctx context.Context, executablePath string, files []string, timeout time.Duration) ([]csResult, error) {
+	//nolint:gosec // executablePath is the scanner-owned cached extractor binary.
+	cmd := exec.CommandContext(ctx, executablePath, files...)
+	return decodeRoslynCommand(cmd, ctx, timeout)
+}
+
+// decodeRoslynCommand runs cmd and decodes the extractor JSON result stream.
+func decodeRoslynCommand(cmd *exec.Cmd, ctx context.Context, timeout time.Duration) ([]csResult, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("csharp Roslyn extractor timed out after %s", timeout)
+		}
+		return nil, fmt.Errorf("csharp Roslyn extractor failed: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+
+	var results []csResult
+	if err := json.Unmarshal(stdout.Bytes(), &results); err != nil {
+		return nil, fmt.Errorf("decode C# Roslyn extractor output: %w", err)
+	}
+	return results, nil
+}
+
+// ensureCachedRoslynExtractorPublished publishes a self-contained extractor
+// binary once per embedded content hash. Later scans execute the binary
+// directly without dotnet restore/build/run overhead.
+func ensureCachedRoslynExtractorPublished(ctx context.Context, dotnet, projectPath, executablePath string) error {
+	if _, err := os.Stat(executablePath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat cached C# Roslyn extractor binary: %w", err)
+	}
+
+	roslynBuildMu.Lock()
+	defer roslynBuildMu.Unlock()
+
+	if _, err := os.Stat(executablePath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat cached C# Roslyn extractor binary: %w", err)
+	}
+
+	publishDir := filepath.Dir(executablePath)
+	if err := os.MkdirAll(publishDir, 0o700); err != nil {
+		return fmt.Errorf("create cached C# Roslyn extractor publish dir: %w", err)
+	}
+
+	rid, err := dotnetRuntimeIdentifier()
+	if err != nil {
+		return err
+	}
+
+	args := []string{
+		"publish", pathForDotnet(dotnet, projectPath),
+		"-c", "Release",
+		"-r", rid,
+		"--self-contained", "true",
+		"-p:PublishSingleFile=true",
+		"-p:PublishTrimmed=false",
+		"-o", pathForDotnet(dotnet, publishDir),
+		"--nologo",
+	}
+	//nolint:gosec // dotnet is a resolved SDK executable used to publish scanner-owned embedded code.
+	cmd := exec.CommandContext(ctx, dotnet, args...)
+	cmd.Env = dotnetEnv()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("csharp Roslyn extractor publish timed out")
+		}
+		output := strings.TrimSpace(stdout.String() + "\n" + stderr.String())
+		return fmt.Errorf("publish cached C# Roslyn extractor: %w: %s", err, output)
+	}
+	if _, err := os.Stat(executablePath); err != nil {
+		return fmt.Errorf("published C# Roslyn extractor binary missing at %s: %w", executablePath, err)
+	}
+	//nolint:gosec // cached self-contained binary must be executable by the scanner.
+	if err := os.Chmod(executablePath, 0o700); err != nil {
+		return fmt.Errorf("mark cached C# Roslyn extractor executable: %w", err)
+	}
+	return nil
+}
+
+// dotnetRuntimeIdentifier returns the Runtime Identifier used to publish the
+// cached extractor for the current OS and architecture.
+func dotnetRuntimeIdentifier() (string, error) {
+	arch := map[string]string{
+		"amd64": "x64",
+		"arm64": "arm64",
+	}[runtime.GOARCH]
+	if arch == "" {
+		return "", fmt.Errorf("unsupported architecture for C# Roslyn extractor publish: %s", runtime.GOARCH)
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		return "linux-" + arch, nil
+	case "darwin":
+		return "osx-" + arch, nil
+	case "windows":
+		return "win-" + arch, nil
+	default:
+		return "", fmt.Errorf("unsupported OS for C# Roslyn extractor publish: %s", runtime.GOOS)
+	}
+}
+
+// pathForDotnet converts WSL /mnt/<drive>/... paths to Windows paths when the
+// selected dotnet executable is Windows dotnet. Linux dotnet must keep POSIX
+// paths unchanged.
+func pathForDotnet(dotnet, path string) string {
+	resolved := dotnet
+	if realPath, err := filepath.EvalSymlinks(dotnet); err == nil {
+		resolved = realPath
+	}
+	if runtime.GOOS != "linux" || !strings.HasPrefix(filepath.ToSlash(resolved), "/mnt/") {
+		return path
+	}
+
+	slashPath := filepath.ToSlash(path)
+	parts := strings.SplitN(strings.TrimPrefix(slashPath, "/mnt/"), "/", 2)
+	if len(parts) != 2 || len(parts[0]) != 1 {
+		return path
+	}
+	return strings.ToUpper(parts[0]) + `:\` + strings.ReplaceAll(parts[1], "/", `\`)
+}
+
+// cachedExtractorName returns the binary name emitted by dotnet publish.
+func cachedExtractorName() string {
+	if runtime.GOOS == "windows" {
+		return "RoslynExtractor.exe"
+	}
+	return "RoslynExtractor"
+}
+
+type roslynRuntimeProject struct {
+	projectPath    string
+	executablePath string
+	cached         bool
+	cleanup        func()
+}
+
+// roslynProject returns a caller-provided project path or a cached copy of the
+// embedded extractor keyed by the embedded project content hash.
+func (s *Scanner) roslynProject() (roslynRuntimeProject, error) {
+	if strings.TrimSpace(s.ProjectPath) != "" {
+		return roslynRuntimeProject{projectPath: s.ProjectPath, cleanup: func() {}}, nil
+	}
+	cacheRoot, err := s.roslynCacheRoot()
+	if err != nil {
+		return roslynRuntimeProject{}, err
+	}
+	return cachedRoslynProject(cacheRoot)
+}
+
+// roslynCacheRoot returns a cache root visible to the dotnet process. Windows
+// dotnet invoked from WSL cannot read Linux-only paths such as /home, so that
+// case uses a cache location on the mounted Windows user profile.
+func (s *Scanner) roslynCacheRoot() (string, error) {
+	dotnetPath := strings.TrimSpace(s.DotnetPath)
+	if dotnetPath == "" {
+		if path, err := exec.LookPath("dotnet"); err == nil {
+			dotnetPath = path
+		}
+	}
+	if resolved, err := filepath.EvalSymlinks(dotnetPath); err == nil {
+		dotnetPath = resolved
+	}
+	if runtime.GOOS == "linux" && strings.HasPrefix(filepath.ToSlash(dotnetPath), "/mnt/") {
+		if root, ok := windowsAccessibleCacheRoot(); ok {
+			return root, nil
+		}
+	}
+	cacheRoot, err := userCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user cache dir for Roslyn extractor: %w", err)
+	}
+	return filepath.Join(cacheRoot, "valk-guard"), nil
+}
+
+// windowsAccessibleCacheRoot derives a Windows-profile cache path from a WSL
+// checkout under /mnt/<drive>/Users/<user>/....
+func windowsAccessibleCacheRoot() (string, bool) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	parts := strings.Split(filepath.ToSlash(wd), "/")
+	if len(parts) < 5 || parts[1] != "mnt" || !strings.EqualFold(parts[3], "users") {
+		return "", false
+	}
+	return filepath.Clean("/" + filepath.Join(parts[1], parts[2], parts[3], parts[4], "AppData", "Local", "valk-guard")), true
+}
+
+// cachedRoslynProject materializes the embedded C# extractor under cacheRoot so
+// repeated scans can execute a published binary.
+func cachedRoslynProject(cacheRoot string) (roslynRuntimeProject, error) {
+	csproj, program, err := embeddedRoslynFiles()
+	if err != nil {
+		return roslynRuntimeProject{}, err
+	}
+
+	sum := sha256.Sum256(append(append([]byte{}, csproj...), program...))
+	cacheDir := filepath.Join(cacheRoot, "roslynextractor-"+hex.EncodeToString(sum[:])[:16])
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return roslynRuntimeProject{}, fmt.Errorf("create cached Roslyn extractor dir: %w", err)
+	}
+
+	projectPath := filepath.Join(cacheDir, "RoslynExtractor.csproj")
+	programPath := filepath.Join(cacheDir, "Program.cs")
+	if err := writeFileIfDifferent(projectPath, csproj, 0o600); err != nil {
+		return roslynRuntimeProject{}, fmt.Errorf("write cached Roslyn project: %w", err)
+	}
+	if err := writeFileIfDifferent(programPath, program, 0o600); err != nil {
+		return roslynRuntimeProject{}, fmt.Errorf("write cached Roslyn program: %w", err)
+	}
+
+	return roslynRuntimeProject{
+		projectPath:    projectPath,
+		executablePath: filepath.Join(cacheDir, "publish", cachedExtractorName()),
+		cached:         true,
+		cleanup:        func() {},
+	}, nil
+}
+
+// dotnetExecutable resolves the dotnet executable, returning a scanner-specific
+// error when C# candidates exist but the .NET SDK is unavailable.
+func (s *Scanner) dotnetExecutable() (string, error) {
+	name := strings.TrimSpace(s.DotnetPath)
+	if name == "" {
+		name = "dotnet"
+	}
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return "", fmt.Errorf("%s; install dotnet or disable the csharp source in .valk-guard.yaml", missingDotnetErrorMsg)
+	}
+	return path, nil
+}
+
+// dotnetEnv keeps .NET subprocesses deterministic and quiet in local scans and
+// CI jobs.
+func dotnetEnv() []string {
+	return append(os.Environ(), "DOTNET_CLI_TELEMETRY_OPTOUT=1", "DOTNET_NOLOGO=1", "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1")
+}
+
+// embeddedRoslynFiles reads the embedded extractor project files.
+func embeddedRoslynFiles() (csproj, program []byte, err error) {
+	csproj, err = roslynProject.ReadFile(csprojEmbedPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	program, err = roslynProject.ReadFile(programEmbedPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	return csproj, program, nil
+}
+
+// writeFileIfDifferent avoids rewriting cached project files when their bytes
+// have not changed, preserving incremental build outputs.
+func writeFileIfDifferent(path string, data []byte, perm fs.FileMode) error {
+	existing, err := os.ReadFile(path) //nolint:gosec // path is scanner-owned cache content
+	if err == nil && bytes.Equal(existing, data) {
+		return nil
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return os.WriteFile(path, data, perm)
+}
+
+// yieldWithDirectives attaches inline valk-guard disable directives from each
+// C# file to the extracted SQL statements before yielding them to the engine.
+func yieldWithDirectives(
+	ctx context.Context,
+	extracted []csResult,
+	yield func(scanner.SQLStatement, error) bool,
+) {
+	directiveCache := make(map[string][]scanner.Directive)
+
+	for _, e := range extracted {
+		if err := ctx.Err(); err != nil {
+			_ = yield(scanner.SQLStatement{}, err)
+			return
+		}
+		if !scanner.LooksLikeSQL(e.SQL) {
 			continue
 		}
 
-		var vars map[string]varDef
-		if scope != nil {
-			vars = collectVars(src[scope.bodyStart:c.dotPos])
+		directives, ok := directiveCache[e.File]
+		if !ok {
+			data, err := os.ReadFile(e.File) //nolint:gosec // file was already selected for scanning
+			if err != nil {
+				_ = yield(scanner.SQLStatement{}, fmt.Errorf("reading C# file %s for directives: %w", e.File, err))
+				return
+			}
+			directives = scanner.ParseDirectives(strings.Split(string(data), "\n"))
+			directiveCache[e.File] = directives
 		}
 
-		isInterp := isInterpolatedMethod(c.method)
-		sql, ok := parseExpr(c.firstArg, vars, isInterp, 0)
-		if !ok || sql == "" {
-			continue
-		}
-		if !isInterp {
-			sql = normalizeFormatPlaceholders(sql)
-		}
-		if !scanner.LooksLikeSQL(sql) {
-			continue
-		}
-
-		line, col := offsetToLC(offsets, c.dotPos)
-		eLine, eCol := offsetToLC(offsets, c.closePos)
-
-		stmts = append(stmts, scanner.SQLStatement{
-			SQL:       sql,
-			File:      path,
-			Line:      line,
-			Column:    col,
-			EndLine:   eLine,
-			EndColumn: eCol,
+		if !yield(scanner.SQLStatement{
+			SQL:       e.SQL,
+			File:      e.File,
+			Line:      e.Line,
+			Column:    e.Column,
+			EndLine:   e.EndLine,
+			EndColumn: e.EndColumn,
 			Engine:    scanner.EngineCSharp,
-			Disabled:  scanner.DisabledRulesForLine(directives, line),
-		})
-	}
-	return stmts
-}
-
-// isInterpolatedMethod reports whether name expects an interpolated SQL string.
-func isInterpolatedMethod(name string) bool {
-	_, ok := interpolatedMethods[name]
-	return ok
-}
-
-// ---------------------------------------------------------------------------
-// Call finding
-// ---------------------------------------------------------------------------
-
-type callSite struct {
-	dotPos   int    // position of the '.' before the method name
-	method   string // method name
-	firstArg string // raw text of the first argument
-	closePos int    // position of closing ')'
-}
-
-type methodScope struct {
-	bodyStart      int
-	bodyEnd        int
-	dbFacadeParams map[string]struct{}
-}
-
-// findCalls locates candidate ExecuteSql* call sites in source text.
-func findCalls(src string) []callSite {
-	var result []callSite
-	n := len(src)
-
-	for i := 0; i < n; {
-		if next := skipNonCode(src, i); next > i {
-			i = next
-			continue
-		}
-		if src[i] == '.' {
-			if c, next := tryMatchCall(src, i); next > 0 {
-				result = append(result, c)
-				i = next
-				continue
-			}
-		}
-		i++
-	}
-	return result
-}
-
-// tryMatchCall matches a supported ExecuteSql* invocation at dotPos.
-func tryMatchCall(src string, dotPos int) (call callSite, next int) {
-	n := len(src)
-	for _, method := range efCoreMethodNames {
-		end := dotPos + 1 + len(method)
-		if end > n {
-			continue
-		}
-		if src[dotPos+1:end] != method {
-			continue
-		}
-		// Ensure the match is not a prefix of a longer identifier.
-		if end < n && isIdentByte(src[end]) {
-			continue
-		}
-		// Skip whitespace to opening '('.
-		j := end
-		for j < n && isWS(src[j]) {
-			j++
-		}
-		if j >= n || src[j] != '(' {
-			continue
-		}
-		argText, closePos := extractFirstArg(src, j+1)
-		if closePos < 0 {
-			continue
-		}
-		return callSite{
-			dotPos:   dotPos,
-			method:   method,
-			firstArg: argText,
-			closePos: closePos,
-		}, closePos + 1
-	}
-	return callSite{}, 0
-}
-
-// receiverAllowed reports whether the call receiver matches a supported EF Core pattern.
-func receiverAllowed(src string, dotPos int, scope *methodScope) bool {
-	member, prev, ok := receiverMembers(src, dotPos)
-	if !ok {
-		return false
-	}
-	if member == "Database" {
-		return prev != ""
-	}
-	if scope == nil {
-		return false
-	}
-
-	names := make(map[string]struct{}, len(scope.dbFacadeParams))
-	for name := range scope.dbFacadeParams {
-		names[name] = struct{}{}
-	}
-	for name := range collectDatabaseFacadeNames(src[scope.bodyStart:dotPos]) {
-		names[name] = struct{}{}
-	}
-
-	if _, ok := names[member]; ok {
-		return true
-	}
-	return (prev == "this" || prev == "base") && hasName(names, member)
-}
-
-// receiverMembers returns the immediate receiver member and its parent member.
-func receiverMembers(src string, dotPos int) (member, prev string, ok bool) {
-	j := dotPos - 1
-	for j >= 0 && isWS(src[j]) {
-		j--
-	}
-	if j < 0 || !isIdentByte(src[j]) {
-		return "", "", false
-	}
-	end := j + 1
-	for j >= 0 && isIdentByte(src[j]) {
-		j--
-	}
-	member = src[j+1 : end]
-
-	k := j
-	for k >= 0 && isWS(src[k]) {
-		k--
-	}
-	if k < 0 || src[k] != '.' {
-		return member, "", true
-	}
-	k--
-	for k >= 0 && isWS(src[k]) {
-		k--
-	}
-	if k < 0 || !isIdentByte(src[k]) {
-		return member, "", true
-	}
-	prevEnd := k + 1
-	for k >= 0 && isIdentByte(src[k]) {
-		k--
-	}
-	return member, src[k+1 : prevEnd], true
-}
-
-// extractFirstArg extracts the raw text of the first argument from a call.
-// pos is the position after '('. Returns (argText, closeParenPos).
-func extractFirstArg(src string, pos int) (argText string, closeParenPos int) {
-	n := len(src)
-	depth := 1
-
-	start := pos
-	for start < n && isWS(src[start]) {
-		start++
-	}
-	argEnd := -1
-
-	for i := start; i < n; {
-		if next := skipNonCode(src, i); next > i {
-			i = next
-			continue
-		}
-		switch src[i] {
-		case '(':
-			depth++
-		case ')':
-			depth--
-			if depth == 0 {
-				if argEnd < 0 {
-					argEnd = i
-				}
-				return strings.TrimSpace(src[start:argEnd]), i
-			}
-		case ',':
-			if depth == 1 && argEnd < 0 {
-				argEnd = i
-			}
-		}
-		i++
-	}
-	return "", -1
-}
-
-// collectMethodScopes finds method-like bodies and the DatabaseFacade params they declare.
-func collectMethodScopes(src string) []methodScope {
-	var scopes []methodScope
-	for i := 0; i < len(src); i++ {
-		if next := skipNonCode(src, i); next > i {
-			i = next - 1
-			continue
-		}
-		if src[i] != '{' {
-			continue
-		}
-		closeParen := prevNonWS(src, i-1)
-		if closeParen < 0 || src[closeParen] != ')' {
-			continue
-		}
-		openParen := findMatchingOpenParen(src, closeParen)
-		if openParen < 0 {
-			continue
-		}
-		name := identBeforePos(src, openParen)
-		if name == "" || isMethodBlockKeyword(name) {
-			continue
-		}
-		closeBrace := findMatchingCloseBrace(src, i)
-		if closeBrace < 0 {
-			continue
-		}
-		scopes = append(scopes, methodScope{
-			bodyStart:      i + 1,
-			bodyEnd:        closeBrace,
-			dbFacadeParams: collectDatabaseFacadeNames(src[openParen+1 : closeParen]),
-		})
-	}
-	return scopes
-}
-
-// findMethodScope returns the innermost method scope containing pos.
-func findMethodScope(scopes []methodScope, pos int) *methodScope {
-	var best *methodScope
-	bestLen := 0
-	for i := range scopes {
-		scope := &scopes[i]
-		if pos < scope.bodyStart || pos > scope.bodyEnd {
-			continue
-		}
-		length := scope.bodyEnd - scope.bodyStart
-		if best == nil || length < bestLen {
-			best = scope
-			bestLen = length
+			Disabled:  scanner.DisabledRulesForLine(directives, e.Line),
+		}, nil) {
+			return
 		}
 	}
-	return best
-}
-
-// findMatchingOpenParen returns the matching '(' for a ')' at closePos.
-func findMatchingOpenParen(src string, closePos int) int {
-	depth := 0
-	for i := closePos; i >= 0; i-- {
-		switch src[i] {
-		case ')':
-			depth++
-		case '(':
-			depth--
-			if depth == 0 {
-				return i
-			}
-		}
-	}
-	return -1
-}
-
-// findMatchingCloseBrace returns the matching '}' for a '{' at openPos.
-func findMatchingCloseBrace(src string, openPos int) int {
-	depth := 0
-	for i := openPos; i < len(src); i++ {
-		if next := skipNonCode(src, i); next > i {
-			i = next - 1
-			continue
-		}
-		switch src[i] {
-		case '{':
-			depth++
-		case '}':
-			depth--
-			if depth == 0 {
-				return i
-			}
-		}
-	}
-	return -1
-}
-
-var methodBlockKeywords = map[string]struct{}{
-	"if": {}, "for": {}, "foreach": {}, "while": {}, "switch": {},
-	"catch": {}, "using": {}, "lock": {}, "checked": {}, "unchecked": {},
-}
-
-// isMethodBlockKeyword reports whether name begins a control-flow block, not a method.
-func isMethodBlockKeyword(name string) bool {
-	_, ok := methodBlockKeywords[name]
-	return ok
-}
-
-// ---------------------------------------------------------------------------
-// SQL resolution
-// ---------------------------------------------------------------------------
-
-type varDef struct {
-	expr string // raw RHS expression text
-}
-
-// parseExpr tries to resolve a C# expression to SQL text.
-// It handles string literals, variable references, and simple concatenation.
-func parseExpr(expr string, vars map[string]varDef, isInterp bool, depth int) (string, bool) {
-	if depth > 5 {
-		return "", false
-	}
-	expr = strings.TrimSpace(expr)
-	if expr == "" {
-		return "", false
-	}
-
-	var result strings.Builder
-	remaining := expr
-
-	for remaining != "" {
-		remaining = strings.TrimSpace(remaining)
-		if remaining == "" {
-			break
-		}
-
-		// Try string literal.
-		if content, rest, ok := tryParseStringLiteral(remaining); ok {
-			result.WriteString(content)
-			remaining = strings.TrimSpace(rest)
-			if strings.HasPrefix(remaining, "+") {
-				remaining = strings.TrimSpace(remaining[1:])
-				continue
-			}
-			if remaining == "" {
-				return result.String(), true
-			}
-			return "", false
-		}
-
-		// Try identifier (variable reference).
-		name := readIdent(remaining)
-		if name != "" {
-			rest := strings.TrimSpace(remaining[len(name):])
-			if v, ok := vars[name]; ok {
-				resolved, rok := parseExpr(v.expr, vars, isInterp, depth+1)
-				if !rok {
-					return "", false
-				}
-				result.WriteString(resolved)
-				remaining = rest
-				if strings.HasPrefix(remaining, "+") {
-					remaining = strings.TrimSpace(remaining[1:])
-					continue
-				}
-				if remaining == "" {
-					return result.String(), true
-				}
-				return "", false
-			}
-			return "", false // unresolved variable
-		}
-
-		return "", false // unrecognized expression
-	}
-
-	if result.Len() == 0 {
-		return "", false
-	}
-	return result.String(), true
-}
-
-// tryParseStringLiteral attempts to parse a C# string literal from the start
-// of s. Returns (content, rest, ok). The content has interpolation expressions
-// replaced with $1, $2 placeholders and escape sequences decoded.
-func tryParseStringLiteral(s string) (content, rest string, ok bool) {
-	// $@"..." or @$"..." (verbatim interpolated)
-	if strings.HasPrefix(s, `$@"`) || strings.HasPrefix(s, `@$"`) {
-		content, rest := readVerbInterpStr(s[3:])
-		return content, rest, true
-	}
-	// $"""...""" (raw interpolated)
-	if len(s) >= 4 && s[0] == '$' && s[1] == '"' && s[2] == '"' && s[3] == '"' {
-		content, rest := readRawInterpStr(s[4:])
-		return content, rest, true
-	}
-	// $"..." (interpolated)
-	if len(s) >= 2 && s[0] == '$' && s[1] == '"' {
-		content, rest := readInterpStr(s[2:])
-		return content, rest, true
-	}
-	// @"..." (verbatim)
-	if len(s) >= 2 && s[0] == '@' && s[1] == '"' {
-		content, rest := readVerbStr(s[2:])
-		return content, rest, true
-	}
-	// """...""" (raw)
-	if len(s) >= 6 && s[0] == '"' && s[1] == '"' && s[2] == '"' {
-		content, rest := readRawStr(s[3:])
-		return content, rest, true
-	}
-	// regular string literal
-	if len(s) >= 1 && s[0] == '"' {
-		content, rest := readRegStr(s[1:])
-		return content, rest, true
-	}
-	return "", s, false
-}
-
-// ---------------------------------------------------------------------------
-// String content reading — each function starts after the opening delimiter
-// and returns (content, rest) where rest is the text after the closing delimiter.
-// ---------------------------------------------------------------------------
-
-// readRegStr reads a regular C# string ("...") starting after the opening ".
-func readRegStr(s string) (content, rest string) {
-	var b strings.Builder
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case '\\':
-			if i+1 < len(s) {
-				i++
-				switch s[i] {
-				case 'n':
-					b.WriteByte('\n')
-				case 'r':
-					b.WriteByte('\r')
-				case 't':
-					b.WriteByte('\t')
-				case '\\':
-					b.WriteByte('\\')
-				case '"':
-					b.WriteByte('"')
-				case '0':
-					b.WriteByte(0)
-				default:
-					b.WriteByte('\\')
-					b.WriteByte(s[i])
-				}
-			}
-		case '"':
-			return b.String(), strings.TrimSpace(s[i+1:])
-		default:
-			b.WriteByte(s[i])
-		}
-	}
-	return b.String(), ""
-}
-
-// readVerbStr reads a verbatim C# string (@"...") starting after @".
-func readVerbStr(s string) (content, rest string) {
-	var b strings.Builder
-	for i := 0; i < len(s); i++ {
-		if s[i] == '"' {
-			if i+1 < len(s) && s[i+1] == '"' {
-				b.WriteByte('"')
-				i++
-				continue
-			}
-			return b.String(), strings.TrimSpace(s[i+1:])
-		}
-		b.WriteByte(s[i])
-	}
-	return b.String(), ""
-}
-
-// readRawStr reads a raw C# string ("""...""") starting after the opening """.
-func readRawStr(s string) (content, rest string) {
-	for i := 0; i+2 < len(s); i++ {
-		if s[i] == '"' && s[i+1] == '"' && s[i+2] == '"' {
-			return trimRawContent(s[:i]), strings.TrimSpace(s[i+3:])
-		}
-	}
-	return trimRawContent(s), ""
-}
-
-// readInterpStr reads an interpolated C# string ($"...") starting after $".
-// Replaces {expr} with $1, $2, etc.
-func readInterpStr(s string) (content, rest string) {
-	var b strings.Builder
-	ph := 0
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case '\\':
-			if i+1 < len(s) {
-				i++
-				switch s[i] {
-				case 'n':
-					b.WriteByte('\n')
-				case 'r':
-					b.WriteByte('\r')
-				case 't':
-					b.WriteByte('\t')
-				case '\\':
-					b.WriteByte('\\')
-				case '"':
-					b.WriteByte('"')
-				case '0':
-					b.WriteByte(0)
-				default:
-					b.WriteByte('\\')
-					b.WriteByte(s[i])
-				}
-			}
-		case '{':
-			if i+1 < len(s) && s[i+1] == '{' {
-				b.WriteByte('{')
-				i++
-				continue
-			}
-			end := findCloseBrace(s, i+1)
-			ph++
-			fmt.Fprintf(&b, "$%d", ph)
-			i = end
-		case '}':
-			if i+1 < len(s) && s[i+1] == '}' {
-				b.WriteByte('}')
-				i++
-				continue
-			}
-			b.WriteByte('}')
-		case '"':
-			return b.String(), strings.TrimSpace(s[i+1:])
-		default:
-			b.WriteByte(s[i])
-		}
-	}
-	return b.String(), ""
-}
-
-// readVerbInterpStr reads a verbatim interpolated string ($@"..." or @$"...").
-func readVerbInterpStr(s string) (content, rest string) {
-	var b strings.Builder
-	ph := 0
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case '{':
-			if i+1 < len(s) && s[i+1] == '{' {
-				b.WriteByte('{')
-				i++
-				continue
-			}
-			end := findCloseBrace(s, i+1)
-			ph++
-			fmt.Fprintf(&b, "$%d", ph)
-			i = end
-		case '}':
-			if i+1 < len(s) && s[i+1] == '}' {
-				b.WriteByte('}')
-				i++
-				continue
-			}
-			b.WriteByte('}')
-		case '"':
-			if i+1 < len(s) && s[i+1] == '"' {
-				b.WriteByte('"')
-				i++
-				continue
-			}
-			return b.String(), strings.TrimSpace(s[i+1:])
-		default:
-			b.WriteByte(s[i])
-		}
-	}
-	return b.String(), ""
-}
-
-// readRawInterpStr reads a raw interpolated string ($"""...""").
-func readRawInterpStr(s string) (content, rest string) {
-	var b strings.Builder
-	ph := 0
-	for i := 0; i < len(s); i++ {
-		if i+2 < len(s) && s[i] == '"' && s[i+1] == '"' && s[i+2] == '"' {
-			return trimRawContent(b.String()), strings.TrimSpace(s[i+3:])
-		}
-		switch s[i] {
-		case '{':
-			if i+1 < len(s) && s[i+1] == '{' {
-				b.WriteByte('{')
-				i++
-				continue
-			}
-			end := findCloseBrace(s, i+1)
-			ph++
-			fmt.Fprintf(&b, "$%d", ph)
-			i = end
-		case '}':
-			if i+1 < len(s) && s[i+1] == '}' {
-				b.WriteByte('}')
-				i++
-				continue
-			}
-			b.WriteByte('}')
-		default:
-			b.WriteByte(s[i])
-		}
-	}
-	return trimRawContent(b.String()), ""
-}
-
-// findCloseBrace finds the matching } for an interpolation expression.
-// It handles all C# string literal types (regular, verbatim, raw,
-// interpolated) inside the expression by reusing skipStringLit.
-func findCloseBrace(s string, pos int) int {
-	depth := 1
-	for i := pos; i < len(s) && depth > 0; {
-		// Skip any string/char literal that starts at i.
-		if next := skipStringLit(s, i); next > i {
-			i = next
-			continue
-		}
-		switch s[i] {
-		case '{':
-			depth++
-		case '}':
-			depth--
-			if depth == 0 {
-				return i
-			}
-		}
-		i++
-	}
-	return len(s) - 1
-}
-
-// trimRawContent strips the required leading/trailing newlines from raw string content.
-func trimRawContent(s string) string {
-	if strings.HasPrefix(s, "\r\n") {
-		s = s[2:]
-	} else if strings.HasPrefix(s, "\n") {
-		s = s[1:]
-	}
-	if strings.HasSuffix(s, "\r\n") {
-		s = s[:len(s)-2]
-	} else if strings.HasSuffix(s, "\n") {
-		s = s[:len(s)-1]
-	}
-	return s
-}
-
-// ---------------------------------------------------------------------------
-// Code region skipping — used to identify code vs non-code (comments/strings)
-// ---------------------------------------------------------------------------
-
-// skipNonCode skips past comments, strings, and char literals at position i.
-// Returns the position after the skipped element, or i if nothing to skip.
-func skipNonCode(src string, i int) int {
-	n := len(src)
-	// Line comment
-	if i+1 < n && src[i] == '/' && src[i+1] == '/' {
-		j := i + 2
-		for j < n && src[j] != '\n' {
-			j++
-		}
-		if j < n {
-			j++
-		}
-		return j
-	}
-	// Block comment
-	if i+1 < n && src[i] == '/' && src[i+1] == '*' {
-		j := i + 2
-		for j+1 < n {
-			if src[j] == '*' && src[j+1] == '/' {
-				return j + 2
-			}
-			j++
-		}
-		return n
-	}
-	return skipStringLit(src, i)
-}
-
-// skipStringLit checks if position i starts a string or char literal.
-func skipStringLit(src string, i int) int {
-	n := len(src)
-	// $@"..." or @$"..."
-	if i+2 < n &&
-		((src[i] == '$' && src[i+1] == '@' && src[i+2] == '"') ||
-			(src[i] == '@' && src[i+1] == '$' && src[i+2] == '"')) {
-		return skipVerbInterpStrLit(src, i+3)
-	}
-	// $"""..."""
-	if i+3 < n && src[i] == '$' && src[i+1] == '"' && src[i+2] == '"' && src[i+3] == '"' {
-		return skipRawStrLit(src, i+4)
-	}
-	// $"..."
-	if i+1 < n && src[i] == '$' && src[i+1] == '"' {
-		return skipInterpStrLit(src, i+2)
-	}
-	// @"..."
-	if i+1 < n && src[i] == '@' && src[i+1] == '"' {
-		return skipVerbStrLit(src, i+2)
-	}
-	// """..."""
-	if i+2 < n && src[i] == '"' && src[i+1] == '"' && src[i+2] == '"' {
-		return skipRawStrLit(src, i+3)
-	}
-	// "..."
-	if i < n && src[i] == '"' {
-		return skipRegStrLit(src, i+1)
-	}
-	// '...'
-	if i < n && src[i] == '\'' {
-		return skipCharLit(src, i+1)
-	}
-	return i
-}
-
-// skipRegStrLit skips a regular string literal and returns the next position.
-func skipRegStrLit(src string, pos int) int {
-	for i := pos; i < len(src); i++ {
-		if src[i] == '\\' {
-			i++
-			continue
-		}
-		if src[i] == '"' {
-			return i + 1
-		}
-	}
-	return len(src)
-}
-
-// skipVerbStrLit skips a verbatim string literal and returns the next position.
-func skipVerbStrLit(src string, pos int) int {
-	for i := pos; i < len(src); i++ {
-		if src[i] == '"' {
-			if i+1 < len(src) && src[i+1] == '"' {
-				i++
-				continue
-			}
-			return i + 1
-		}
-	}
-	return len(src)
-}
-
-// skipInterpStrLit skips an interpolated string literal and returns the next position.
-func skipInterpStrLit(src string, pos int) int {
-	for i := pos; i < len(src); i++ {
-		switch src[i] {
-		case '\\':
-			i++
-		case '{':
-			if i+1 < len(src) && src[i+1] == '{' {
-				i++
-				continue
-			}
-			i = skipBraceExprLit(src, i+1) - 1
-		case '"':
-			return i + 1
-		}
-	}
-	return len(src)
-}
-
-// skipVerbInterpStrLit skips a verbatim interpolated string literal.
-func skipVerbInterpStrLit(src string, pos int) int {
-	for i := pos; i < len(src); i++ {
-		switch src[i] {
-		case '{':
-			if i+1 < len(src) && src[i+1] == '{' {
-				i++
-				continue
-			}
-			i = skipBraceExprLit(src, i+1) - 1
-		case '"':
-			if i+1 < len(src) && src[i+1] == '"' {
-				i++
-				continue
-			}
-			return i + 1
-		}
-	}
-	return len(src)
-}
-
-// skipRawStrLit skips a raw string literal and returns the next position.
-func skipRawStrLit(src string, pos int) int {
-	for i := pos; i+2 < len(src); i++ {
-		if src[i] == '"' && src[i+1] == '"' && src[i+2] == '"' {
-			return i + 3
-		}
-	}
-	return len(src)
-}
-
-// skipCharLit skips a character literal and returns the next position.
-func skipCharLit(src string, pos int) int {
-	for i := pos; i < len(src); i++ {
-		if src[i] == '\\' {
-			i++
-			continue
-		}
-		if src[i] == '\'' {
-			return i + 1
-		}
-	}
-	return len(src)
-}
-
-// skipBraceExprLit skips an interpolated brace expression and returns the next position.
-func skipBraceExprLit(src string, pos int) int {
-	depth := 1
-	for i := pos; i < len(src) && depth > 0; i++ {
-		if next := skipStringLit(src, i); next > i {
-			i = next - 1
-			continue
-		}
-		switch src[i] {
-		case '{':
-			depth++
-		case '}':
-			depth--
-			if depth == 0 {
-				return i + 1
-			}
-		}
-	}
-	return len(src)
-}
-
-// ---------------------------------------------------------------------------
-// Variable collection
-// ---------------------------------------------------------------------------
-
-// collectVars gathers simple string-backed variable assignments from src.
-func collectVars(src string) map[string]varDef {
-	vars := make(map[string]varDef)
-	n := len(src)
-
-	for i := 0; i < n; {
-		if next := skipNonCode(src, i); next > i {
-			i = next
-			continue
-		}
-		if src[i] == '=' && !isCompoundOrComparison(src, i, n) {
-			name := identBefore(src, i)
-			if name == "" || isCSharpKeyword(name) {
-				i++
-				continue
-			}
-			rhsStart := i + 1
-			for rhsStart < n && isWS(src[rhsStart]) {
-				rhsStart++
-			}
-			rhsEnd := findSemicolon(src, rhsStart)
-			if rhsEnd < 0 {
-				i++
-				continue
-			}
-			rhs := strings.TrimSpace(src[rhsStart:rhsEnd])
-			if rhs != "" && isStringLiteralStart(rhs) {
-				vars[name] = varDef{expr: rhs}
-			}
-			i = rhsEnd + 1
-			continue
-		}
-		i++
-	}
-	return vars
-}
-
-// collectDatabaseFacadeNames extracts identifiers declared with DatabaseFacade type text.
-func collectDatabaseFacadeNames(src string) map[string]struct{} {
-	names := make(map[string]struct{})
-	n := len(src)
-
-	for i := 0; i < n; {
-		if next := skipNonCode(src, i); next > i {
-			i = next
-			continue
-		}
-		typeLen := matchDatabaseFacadeType(src, i)
-		if typeLen == 0 {
-			i++
-			continue
-		}
-
-		j := i + typeLen
-		for j < n && isWS(src[j]) {
-			j++
-		}
-		if j < n && src[j] == '?' {
-			j++
-			for j < n && isWS(src[j]) {
-				j++
-			}
-		}
-
-		name := readIdent(src[j:])
-		if name != "" && !isCSharpKeyword(name) {
-			names[name] = struct{}{}
-			i = j + len(name)
-			continue
-		}
-		i++
-	}
-
-	return names
-}
-
-// matchDatabaseFacadeType reports the length of a DatabaseFacade type token at pos.
-func matchDatabaseFacadeType(src string, pos int) int {
-	candidates := []string{
-		"Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade",
-		"DatabaseFacade",
-	}
-	for _, candidate := range candidates {
-		end := pos + len(candidate)
-		if end > len(src) || src[pos:end] != candidate {
-			continue
-		}
-		if pos > 0 && (isIdentByte(src[pos-1]) || src[pos-1] == '.') {
-			continue
-		}
-		if end < len(src) && (isIdentByte(src[end]) || src[end] == '.') {
-			continue
-		}
-		return len(candidate)
-	}
-	return 0
-}
-
-// isCompoundOrComparison reports whether '=' at i belongs to a non-assignment operator.
-func isCompoundOrComparison(src string, i, n int) bool {
-	if i+1 < n && (src[i+1] == '=' || src[i+1] == '>') {
-		return true
-	}
-	if i > 0 {
-		p := src[i-1]
-		if p == '!' || p == '<' || p == '>' || p == '=' ||
-			p == '+' || p == '-' || p == '*' || p == '/' ||
-			p == '%' || p == '&' || p == '|' || p == '^' || p == '?' {
-			return true
-		}
-	}
-	return false
-}
-
-// identBefore returns the identifier immediately before pos, excluding member assignments.
-func identBefore(src string, pos int) string {
-	j := pos - 1
-	for j >= 0 && (src[j] == ' ' || src[j] == '\t') {
-		j--
-	}
-	if j < 0 || !isIdentByte(src[j]) {
-		return ""
-	}
-	end := j + 1
-	for j >= 0 && isIdentByte(src[j]) {
-		j--
-	}
-	name := src[j+1 : end]
-	// Reject member/property assignments like obj.Query = "..." — the dot
-	// means this is not a local variable declaration.
-	if j >= 0 && src[j] == '.' {
-		return ""
-	}
-	return name
-}
-
-// identBeforePos returns the identifier immediately preceding pos.
-func identBeforePos(src string, pos int) string {
-	j := prevNonWS(src, pos-1)
-	if j < 0 || !isIdentByte(src[j]) {
-		return ""
-	}
-	end := j + 1
-	for j >= 0 && isIdentByte(src[j]) {
-		j--
-	}
-	return src[j+1 : end]
-}
-
-// findSemicolon returns the next statement terminator starting from pos.
-func findSemicolon(src string, pos int) int {
-	for i := pos; i < len(src); {
-		if next := skipNonCode(src, i); next > i {
-			i = next
-			continue
-		}
-		if src[i] == ';' {
-			return i
-		}
-		if src[i] == '{' || src[i] == '}' {
-			return -1
-		}
-		i++
-	}
-	return -1
-}
-
-// isStringLiteralStart reports whether s begins with a supported C# string literal.
-func isStringLiteralStart(s string) bool {
-	if s == "" {
-		return false
-	}
-	switch s[0] {
-	case '"':
-		return true
-	case '@':
-		return len(s) > 1 && (s[1] == '"' || (s[1] == '$' && len(s) > 2 && s[2] == '"'))
-	case '$':
-		return len(s) > 1 && (s[1] == '"' || (s[1] == '@' && len(s) > 2 && s[2] == '"'))
-	}
-	return false
-}
-
-var csharpKeywords = map[string]struct{}{
-	"if": {}, "else": {}, "for": {}, "foreach": {}, "while": {},
-	"do": {}, "switch": {}, "case": {}, "break": {}, "continue": {},
-	"return": {}, "new": {}, "null": {}, "true": {}, "false": {},
-	"this": {}, "base": {}, "class": {}, "struct": {}, "interface": {},
-	"void": {}, "typeof": {}, "sizeof": {}, "nameof": {},
-	"throw": {}, "try": {}, "catch": {}, "finally": {},
-	"lock": {}, "using": {}, "checked": {}, "unchecked": {},
-	"default": {}, "delegate": {}, "event": {}, "fixed": {},
-	"goto": {}, "implicit": {}, "explicit": {}, "extern": {},
-	"operator": {}, "params": {}, "ref": {}, "out": {},
-	"stackalloc": {}, "unsafe": {}, "volatile": {},
-}
-
-// isCSharpKeyword reports whether s is a reserved C# keyword used for filtering.
-func isCSharpKeyword(s string) bool {
-	_, ok := csharpKeywords[s]
-	return ok
-}
-
-// hasName reports whether name exists in the identifier set.
-func hasName(names map[string]struct{}, name string) bool {
-	_, ok := names[name]
-	return ok
-}
-
-// ---------------------------------------------------------------------------
-// Placeholder normalization
-// ---------------------------------------------------------------------------
-
-// normalizeFormatPlaceholders converts .NET format string placeholders ({0},
-// {1}, ...) to PostgreSQL-style placeholders ($1, $2, ...).
-func normalizeFormatPlaceholders(sql string) string {
-	var b strings.Builder
-	changed := false
-	for i := 0; i < len(sql); i++ {
-		if sql[i] == '{' {
-			j := i + 1
-			for j < len(sql) && sql[j] >= '0' && sql[j] <= '9' {
-				j++
-			}
-			if j > i+1 && j < len(sql) && sql[j] == '}' {
-				num := 0
-				for k := i + 1; k < j; k++ {
-					num = num*10 + int(sql[k]-'0')
-				}
-				fmt.Fprintf(&b, "$%d", num+1)
-				i = j
-				changed = true
-				continue
-			}
-		}
-		b.WriteByte(sql[i])
-	}
-	if !changed {
-		return sql
-	}
-	return b.String()
-}
-
-// ---------------------------------------------------------------------------
-// Utility helpers
-// ---------------------------------------------------------------------------
-
-// buildLineOffsets builds a line-start offset table for source positions.
-func buildLineOffsets(src string) []int {
-	offsets := []int{0}
-	for i := 0; i < len(src); i++ {
-		if src[i] == '\n' {
-			offsets = append(offsets, i+1)
-		}
-	}
-	return offsets
-}
-
-// offsetToLC converts a byte offset into 1-based line and column coordinates.
-func offsetToLC(offsets []int, pos int) (line, col int) {
-	lo, hi := 0, len(offsets)-1
-	for lo < hi {
-		mid := (lo + hi + 1) / 2
-		if offsets[mid] <= pos {
-			lo = mid
-		} else {
-			hi = mid - 1
-		}
-	}
-	return lo + 1, pos - offsets[lo] + 1
-}
-
-// prevNonWS returns the previous non-whitespace byte index before or at pos.
-func prevNonWS(src string, pos int) int {
-	for pos >= 0 && isWS(src[pos]) {
-		pos--
-	}
-	return pos
-}
-
-// isIdentByte reports whether c is valid in a C# identifier tail.
-func isIdentByte(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-		(c >= '0' && c <= '9') || c == '_'
-}
-
-// readIdent reads the leading C# identifier from s.
-func readIdent(s string) string {
-	if s == "" {
-		return ""
-	}
-	c := s[0]
-	if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && c != '_' {
-		return ""
-	}
-	i := 1
-	for i < len(s) && isIdentByte(s[i]) {
-		i++
-	}
-	return s[:i]
-}
-
-// isWS reports whether c is recognized as scanner whitespace.
-func isWS(c byte) bool {
-	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
 }

--- a/internal/scanner/csharp/scanner.go
+++ b/internal/scanner/csharp/scanner.go
@@ -96,7 +96,7 @@ func walkCSFiles(ctx context.Context, paths []string, fn func(string, []byte) er
 			if !isCS(root) {
 				continue
 			}
-			data, err := os.ReadFile(root)
+			data, err := os.ReadFile(root) //nolint:gosec // scanning user-provided source paths
 			if err != nil {
 				return fmt.Errorf("read %s: %w", root, err)
 			}
@@ -106,13 +106,16 @@ func walkCSFiles(ctx context.Context, paths []string, fn func(string, []byte) er
 			continue
 		}
 		if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, we error) error {
-			if we != nil || d.IsDir() || !isCS(p) {
+			if we != nil {
+				return we
+			}
+			if d.IsDir() || !isCS(p) {
 				return nil
 			}
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			data, err := os.ReadFile(p)
+			data, err := os.ReadFile(p) //nolint:gosec // scanning user-provided source paths
 			if err != nil {
 				return fmt.Errorf("read %s: %w", p, err)
 			}
@@ -139,9 +142,10 @@ func extractStatements(path, src string) []scanner.SQLStatement {
 	directives := scanner.ParseDirectives(lines)
 	offsets := buildLineOffsets(src)
 	scopes := collectMethodScopes(src)
+	calls := findCalls(src)
 
-	var stmts []scanner.SQLStatement
-	for _, c := range findCalls(src) {
+	stmts := make([]scanner.SQLStatement, 0, len(calls))
+	for _, c := range calls {
 		scope := findMethodScope(scopes, c.dotPos)
 		if !receiverAllowed(src, c.dotPos, scope) {
 			continue
@@ -227,7 +231,7 @@ func findCalls(src string) []callSite {
 }
 
 // tryMatchCall matches a supported ExecuteSql* invocation at dotPos.
-func tryMatchCall(src string, dotPos int) (callSite, int) {
+func tryMatchCall(src string, dotPos int) (call callSite, next int) {
 	n := len(src)
 	for _, method := range efCoreMethodNames {
 		end := dotPos + 1 + len(method)
@@ -291,7 +295,7 @@ func receiverAllowed(src string, dotPos int, scope *methodScope) bool {
 }
 
 // receiverMembers returns the immediate receiver member and its parent member.
-func receiverMembers(src string, dotPos int) (string, string, bool) {
+func receiverMembers(src string, dotPos int) (member, prev string, ok bool) {
 	j := dotPos - 1
 	for j >= 0 && isWS(src[j]) {
 		j--
@@ -303,7 +307,7 @@ func receiverMembers(src string, dotPos int) (string, string, bool) {
 	for j >= 0 && isIdentByte(src[j]) {
 		j--
 	}
-	member := src[j+1 : end]
+	member = src[j+1 : end]
 
 	k := j
 	for k >= 0 && isWS(src[k]) {
@@ -328,7 +332,7 @@ func receiverMembers(src string, dotPos int) (string, string, bool) {
 
 // extractFirstArg extracts the raw text of the first argument from a call.
 // pos is the position after '('. Returns (argText, closeParenPos).
-func extractFirstArg(src string, pos int) (string, int) {
+func extractFirstArg(src string, pos int) (argText string, closeParenPos int) {
 	n := len(src)
 	depth := 1
 
@@ -544,7 +548,7 @@ func parseExpr(expr string, vars map[string]varDef, isInterp bool, depth int) (s
 // tryParseStringLiteral attempts to parse a C# string literal from the start
 // of s. Returns (content, rest, ok). The content has interpolation expressions
 // replaced with $1, $2 placeholders and escape sequences decoded.
-func tryParseStringLiteral(s string) (string, string, bool) {
+func tryParseStringLiteral(s string) (content, rest string, ok bool) {
 	// $@"..." or @$"..." (verbatim interpolated)
 	if strings.HasPrefix(s, `$@"`) || strings.HasPrefix(s, `@$"`) {
 		content, rest := readVerbInterpStr(s[3:])
@@ -570,7 +574,7 @@ func tryParseStringLiteral(s string) (string, string, bool) {
 		content, rest := readRawStr(s[3:])
 		return content, rest, true
 	}
-	// "..." (regular)
+	// regular string literal
 	if len(s) >= 1 && s[0] == '"' {
 		content, rest := readRegStr(s[1:])
 		return content, rest, true
@@ -584,7 +588,7 @@ func tryParseStringLiteral(s string) (string, string, bool) {
 // ---------------------------------------------------------------------------
 
 // readRegStr reads a regular C# string ("...") starting after the opening ".
-func readRegStr(s string) (string, string) {
+func readRegStr(s string) (content, rest string) {
 	var b strings.Builder
 	for i := 0; i < len(s); i++ {
 		switch s[i] {
@@ -619,7 +623,7 @@ func readRegStr(s string) (string, string) {
 }
 
 // readVerbStr reads a verbatim C# string (@"...") starting after @".
-func readVerbStr(s string) (string, string) {
+func readVerbStr(s string) (content, rest string) {
 	var b strings.Builder
 	for i := 0; i < len(s); i++ {
 		if s[i] == '"' {
@@ -636,7 +640,7 @@ func readVerbStr(s string) (string, string) {
 }
 
 // readRawStr reads a raw C# string ("""...""") starting after the opening """.
-func readRawStr(s string) (string, string) {
+func readRawStr(s string) (content, rest string) {
 	for i := 0; i+2 < len(s); i++ {
 		if s[i] == '"' && s[i+1] == '"' && s[i+2] == '"' {
 			return trimRawContent(s[:i]), strings.TrimSpace(s[i+3:])
@@ -647,7 +651,7 @@ func readRawStr(s string) (string, string) {
 
 // readInterpStr reads an interpolated C# string ($"...") starting after $".
 // Replaces {expr} with $1, $2, etc.
-func readInterpStr(s string) (string, string) {
+func readInterpStr(s string) (content, rest string) {
 	var b strings.Builder
 	ph := 0
 	for i := 0; i < len(s); i++ {
@@ -700,7 +704,7 @@ func readInterpStr(s string) (string, string) {
 }
 
 // readVerbInterpStr reads a verbatim interpolated string ($@"..." or @$"...").
-func readVerbInterpStr(s string) (string, string) {
+func readVerbInterpStr(s string) (content, rest string) {
 	var b strings.Builder
 	ph := 0
 	for i := 0; i < len(s); i++ {
@@ -737,7 +741,7 @@ func readVerbInterpStr(s string) (string, string) {
 }
 
 // readRawInterpStr reads a raw interpolated string ($"""...""").
-func readRawInterpStr(s string) (string, string) {
+func readRawInterpStr(s string) (content, rest string) {
 	var b strings.Builder
 	ph := 0
 	for i := 0; i < len(s); i++ {
@@ -1254,7 +1258,7 @@ func buildLineOffsets(src string) []int {
 }
 
 // offsetToLC converts a byte offset into 1-based line and column coordinates.
-func offsetToLC(offsets []int, pos int) (int, int) {
+func offsetToLC(offsets []int, pos int) (line, col int) {
 	lo, hi := 0, len(offsets)-1
 	for lo < hi {
 		mid := (lo + hi + 1) / 2
@@ -1287,7 +1291,7 @@ func readIdent(s string) string {
 		return ""
 	}
 	c := s[0]
-	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_') {
+	if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && c != '_' {
 		return ""
 	}
 	i := 1

--- a/internal/scanner/csharp/scanner_test.go
+++ b/internal/scanner/csharp/scanner_test.go
@@ -1,0 +1,407 @@
+// Copyright 2025 ValkDB
+// SPDX-License-Identifier: Apache-2.0
+
+package csharp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/valkdb/valk-guard/internal/scanner"
+)
+
+// helper writes a .cs file in a temp dir, scans it, and returns statements.
+func scanCS(t *testing.T, src string) []scanner.SQLStatement {
+	t.Helper()
+	tmpDir := t.TempDir()
+	csFile := filepath.Join(tmpDir, "test.cs")
+	if err := os.WriteFile(csFile, []byte(src), 0644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	s := &Scanner{}
+	stmts, err := scanner.Collect(s.Scan(context.Background(), []string{tmpDir}))
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+	return stmts
+}
+
+func TestDirectLiteral(t *testing.T) {
+	src := `using Microsoft.EntityFrameworkCore;
+
+class Repo {
+    void Run(MyDbContext db) {
+        db.Database.ExecuteSqlRaw("DELETE FROM temp_data WHERE created_at < NOW()");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(stmts))
+	}
+	want := "DELETE FROM temp_data WHERE created_at < NOW()"
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+	if stmts[0].Engine != scanner.EngineCSharp {
+		t.Errorf("engine = %q, want %q", stmts[0].Engine, scanner.EngineCSharp)
+	}
+}
+
+func TestVerbatimString(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        db.Database.ExecuteSqlRaw(@"UPDATE users
+            SET active = false
+            WHERE last_login < '2024-01-01'");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	if !strings.HasPrefix(stmts[0].SQL, "UPDATE users") {
+		t.Errorf("unexpected SQL: %q", stmts[0].SQL)
+	}
+	if !strings.Contains(stmts[0].SQL, "WHERE last_login") {
+		t.Errorf("missing WHERE in SQL: %q", stmts[0].SQL)
+	}
+}
+
+func TestRawStringLiteral(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        db.Database.ExecuteSqlRaw("""
+            SELECT id, name
+            FROM users
+            WHERE active = true
+            LIMIT 100
+            """);
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	if !strings.Contains(stmts[0].SQL, "SELECT id, name") {
+		t.Errorf("unexpected SQL: %q", stmts[0].SQL)
+	}
+	if !strings.Contains(stmts[0].SQL, "LIMIT 100") {
+		t.Errorf("missing LIMIT in SQL: %q", stmts[0].SQL)
+	}
+}
+
+func TestInterpolatedString(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db, int userId) {
+        db.Database.ExecuteSqlInterpolated($"DELETE FROM users WHERE id = {userId}");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	want := "DELETE FROM users WHERE id = $1"
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}
+
+func TestLocalVariablePassedToExecuteSqlRaw(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        var sql = "SELECT id FROM users WHERE active = true LIMIT 50";
+        db.Database.ExecuteSqlRaw(sql);
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	want := "SELECT id FROM users WHERE active = true LIMIT 50"
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}
+
+func TestDatabaseFacadeHelper(t *testing.T) {
+	src := `using Microsoft.EntityFrameworkCore.Infrastructure;
+
+class SqlRunner {
+    public void CleanUp(DatabaseFacade database) {
+        database.ExecuteSqlRaw("DELETE FROM temp_data WHERE created_at < NOW() - INTERVAL '1 day'");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	if !strings.HasPrefix(stmts[0].SQL, "DELETE FROM temp_data") {
+		t.Errorf("unexpected SQL: %q", stmts[0].SQL)
+	}
+}
+
+func TestLocalDatabaseFacadeReceiver(t *testing.T) {
+	src := `using Microsoft.EntityFrameworkCore.Infrastructure;
+
+class Repo {
+    void Run(MyDbContext db) {
+        DatabaseFacade database = db.Database;
+        database.ExecuteSqlRaw("DELETE FROM temp_data WHERE created_at < NOW()");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	if !strings.HasPrefix(stmts[0].SQL, "DELETE FROM temp_data") {
+		t.Errorf("unexpected SQL: %q", stmts[0].SQL)
+	}
+}
+
+func TestRejectsNonDatabaseReceiverWithMatchingMethodName(t *testing.T) {
+	src := `class FakeRunner {
+    public void ExecuteSqlRaw(string sql) {}
+}
+
+class Repo {
+    void Run(FakeRunner runner) {
+        runner.ExecuteSqlRaw("DELETE FROM temp_data WHERE created_at < NOW()");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 0 {
+		t.Fatalf("expected 0 for non-EF receiver, got %d: %+v", len(stmts), stmts)
+	}
+}
+
+func TestAsyncVariants(t *testing.T) {
+	src := `class Repo {
+    async Task Run(MyDbContext db, int id) {
+        await db.Database.ExecuteSqlRawAsync("SELECT 1");
+        await db.Database.ExecuteSqlInterpolatedAsync($"DELETE FROM users WHERE id = {id}");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 2 {
+		t.Fatalf("expected 2, got %d", len(stmts))
+	}
+	if stmts[0].SQL != "SELECT 1" {
+		t.Errorf("stmt[0] SQL = %q, want %q", stmts[0].SQL, "SELECT 1")
+	}
+	want := "DELETE FROM users WHERE id = $1"
+	if stmts[1].SQL != want {
+		t.Errorf("stmt[1] SQL = %q, want %q", stmts[1].SQL, want)
+	}
+}
+
+func TestConcatenation(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        db.Database.ExecuteSqlRaw("SELECT * FROM " + "users WHERE id = 1 LIMIT 1");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	want := "SELECT * FROM users WHERE id = 1 LIMIT 1"
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}
+
+func TestVariableResolutionStaysWithinMethodScope(t *testing.T) {
+	src := `class Repo {
+    void Prepare() {
+        var sql = "DELETE FROM temp_data WHERE created_at < NOW()";
+    }
+
+    void Run(MyDbContext db) {
+        db.Database.ExecuteSqlRaw(sql);
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 0 {
+		t.Fatalf("expected 0 for cross-method variable reference, got %d: %+v", len(stmts), stmts)
+	}
+}
+
+func TestUnresolvedDynamicSkipped(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db, string table) {
+        db.Database.ExecuteSqlRaw("SELECT * FROM " + table);
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 0 {
+		t.Fatalf("expected 0 statements for dynamic SQL, got %d: %+v", len(stmts), stmts)
+	}
+}
+
+func TestFormatStringPlaceholders(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db, int id, string name) {
+        db.Database.ExecuteSqlRaw("SELECT * FROM users WHERE id = {0} AND name = {1} LIMIT 1", id, name);
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	want := "SELECT * FROM users WHERE id = $1 AND name = $2 LIMIT 1"
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}
+
+func TestDisableDirective(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        // valk-guard:disable VG001
+        db.Database.ExecuteSqlRaw("SELECT * FROM users LIMIT 10");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	if len(stmts[0].Disabled) != 1 || stmts[0].Disabled[0] != "VG001" {
+		t.Errorf("expected disabled=[VG001], got %v", stmts[0].Disabled)
+	}
+}
+
+func TestSkipsCallsInsideComments(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        // db.Database.ExecuteSqlRaw("SELECT 1");
+        /* db.Database.ExecuteSqlRaw("SELECT 2"); */
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 0 {
+		t.Fatalf("expected 0, got %d: %+v", len(stmts), stmts)
+	}
+}
+
+func TestSkipsCallsInsideStrings(t *testing.T) {
+	src := `class Repo {
+    void Run() {
+        var s = "db.Database.ExecuteSqlRaw(\"SELECT 1\")";
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 0 {
+		t.Fatalf("expected 0, got %d: %+v", len(stmts), stmts)
+	}
+}
+
+func TestVerbatimInterpolated(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db, int id) {
+        db.Database.ExecuteSqlInterpolated($@"UPDATE users
+            SET active = false
+            WHERE id = {id}");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	if !strings.Contains(stmts[0].SQL, "UPDATE users") {
+		t.Errorf("unexpected SQL: %q", stmts[0].SQL)
+	}
+	if !strings.Contains(stmts[0].SQL, "$1") {
+		t.Errorf("missing placeholder in SQL: %q", stmts[0].SQL)
+	}
+}
+
+func TestMultipleInterpolationPlaceholders(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db, int id, string name, bool active) {
+        db.Database.ExecuteSqlInterpolated(
+            $"UPDATE users SET name = {name}, active = {active} WHERE id = {id}");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	want := "UPDATE users SET name = $1, active = $2 WHERE id = $3"
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}
+
+func TestEmptyDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	s := &Scanner{}
+	stmts, err := scanner.Collect(s.Scan(context.Background(), []string{tmpDir}))
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+	if len(stmts) != 0 {
+		t.Errorf("expected 0, got %d", len(stmts))
+	}
+}
+
+func TestNonSQLStringSkipped(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        db.Database.ExecuteSqlRaw("hello world");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 0 {
+		t.Fatalf("expected 0 for non-SQL string, got %d", len(stmts))
+	}
+}
+
+func TestVerbatimStringVariableAssignment(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        string query = @"DELETE FROM temp_data
+            WHERE created_at < NOW()";
+        db.Database.ExecuteSqlRaw(query);
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	if !strings.HasPrefix(stmts[0].SQL, "DELETE FROM temp_data") {
+		t.Errorf("unexpected SQL: %q", stmts[0].SQL)
+	}
+}
+
+func TestPropertyAssignmentNotCaptured(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        obj.Query = "SELECT * FROM secrets";
+        db.Database.ExecuteSqlRaw(Query);
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 0 {
+		t.Fatalf("expected 0 (property assignment should not be captured as var), got %d: %+v", len(stmts), stmts)
+	}
+}
+
+func TestConcatenationWithVariable(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        var prefix = "SELECT id, name FROM ";
+        db.Database.ExecuteSqlRaw(prefix + "users WHERE active = true LIMIT 10");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	want := "SELECT id, name FROM users WHERE active = true LIMIT 10"
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}

--- a/internal/scanner/csharp/scanner_test.go
+++ b/internal/scanner/csharp/scanner_test.go
@@ -6,27 +6,95 @@ package csharp
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/valkdb/valk-guard/internal/scanner"
+	"github.com/valkdb/valk-guard/internal/scannertest"
 )
+
+func TestMain(m *testing.M) {
+	if mode := os.Getenv("VALK_FAKE_DOTNET"); mode != "" {
+		switch mode {
+		case "sleep":
+			time.Sleep(500 * time.Millisecond)
+			os.Exit(0)
+		case "malformed-json":
+			_, _ = os.Stdout.WriteString("{")
+			os.Exit(0)
+		default:
+			_, _ = os.Stdout.WriteString("[]")
+			os.Exit(0)
+		}
+	}
+	os.Exit(m.Run())
+}
+
+// requireDotnet skips Roslyn-dependent scanner tests when the .NET SDK is not
+// available in the local developer environment. GitHub Actions installs .NET,
+// so these tests still run in CI.
+func requireDotnet(t *testing.T) {
+	t.Helper()
+	if path := os.Getenv("VALK_DOTNET_PATH"); path != "" {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("VALK_DOTNET_PATH is set but not usable: %v", err)
+		}
+		return
+	}
+	if _, err := exec.LookPath("dotnet"); err != nil {
+		if os.Getenv("VALK_REQUIRE_DOTNET") == "1" {
+			t.Fatalf("dotnet SDK is required for C# Roslyn scanner tests: %v", err)
+		}
+		t.Skip("dotnet SDK is required for C# Roslyn scanner tests")
+	}
+}
+
+// dotnetPathForTest resolves the dotnet executable for local and CI test runs.
+func dotnetPathForTest() string {
+	if path := os.Getenv("VALK_DOTNET_PATH"); path != "" {
+		return path
+	}
+	return ""
+}
 
 // helper writes a .cs file in a temp dir, scans it, and returns statements.
 func scanCS(t *testing.T, src string) []scanner.SQLStatement {
 	t.Helper()
+	requireDotnet(t)
+	return scanCSWithScanner(t, &Scanner{DotnetPath: dotnetPathForTest(), ProjectPath: testRoslynProjectPath()}, src)
+}
+
+// scanCSWithScanner writes a .cs file and scans it with the provided scanner.
+func scanCSWithScanner(t *testing.T, s *Scanner, src string) []scanner.SQLStatement {
+	t.Helper()
 	tmpDir := t.TempDir()
+	if os.Getenv("VALK_DOTNET_PATH") != "" {
+		var err error
+		tmpDir, err = os.MkdirTemp(".", ".csharp-test-*")
+		if err != nil {
+			t.Fatalf("create local temp dir: %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	}
 	csFile := filepath.Join(tmpDir, "test.cs")
 	if err := os.WriteFile(csFile, []byte(src), 0644); err != nil {
 		t.Fatalf("write temp file: %v", err)
 	}
-	s := &Scanner{}
 	stmts, err := scanner.Collect(s.Scan(context.Background(), []string{tmpDir}))
 	if err != nil {
 		t.Fatalf("scan error: %v", err)
 	}
 	return stmts
+}
+
+// testRoslynProjectPath returns the checked-in extractor project so CI can use
+// incremental dotnet builds across scanner tests.
+func testRoslynProjectPath() string {
+	return filepath.Join("roslynextractor", "RoslynExtractor.csproj")
 }
 
 func TestDirectLiteral(t *testing.T) {
@@ -126,6 +194,77 @@ func TestLocalVariablePassedToExecuteSqlRaw(t *testing.T) {
 	}
 }
 
+func TestLocalConcatenatedVariablePreservesSql(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        var where = " WHERE active = true";
+        var sql = "SELECT id FROM users" + where + " LIMIT 50";
+        db.Database.ExecuteSqlRaw(sql);
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	want := "SELECT id FROM users WHERE active = true LIMIT 50"
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}
+
+func TestLocalInterpolatedVariablePreservesPlaceholder(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db, int id) {
+        var sql = $"DELETE FROM users WHERE id = {id}";
+        db.Database.ExecuteSqlInterpolated(sql);
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	want := "DELETE FROM users WHERE id = $1"
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}
+
+func TestLocalVariableReassignmentUsesLatestBeforeCall(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        var sql = "SELECT * FROM users";
+        sql = "DELETE FROM users WHERE active = false";
+        db.Database.ExecuteSqlRaw(sql);
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	want := "DELETE FROM users WHERE active = false"
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}
+
+func TestLocalInterpolationArgumentCanBeAnotherLocal(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        var id = 42;
+        var sql = $"DELETE FROM users WHERE id = {id}";
+        db.Database.ExecuteSqlInterpolated(sql);
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d", len(stmts))
+	}
+	want := "DELETE FROM users WHERE id = $1"
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}
+
 func TestDatabaseFacadeHelper(t *testing.T) {
 	src := `using Microsoft.EntityFrameworkCore.Infrastructure;
 
@@ -158,6 +297,57 @@ class Repo {
 	}
 	if !strings.HasPrefix(stmts[0].SQL, "DELETE FROM temp_data") {
 		t.Errorf("unexpected SQL: %q", stmts[0].SQL)
+	}
+}
+
+func TestDatabaseFacadeReceiverReassignmentBeforeCall(t *testing.T) {
+	src := `using Microsoft.EntityFrameworkCore.Infrastructure;
+
+class Repo {
+    void Run(MyDbContext db, FakeRunner fake) {
+        DatabaseFacade database = db.Database;
+        database = fake;
+        database.ExecuteSqlRaw("DELETE FROM temp_data WHERE created_at < NOW()");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 0 {
+		t.Fatalf("expected 0 after non-facade reassignment, got %d: %+v", len(stmts), stmts)
+	}
+}
+
+func TestDatabaseFacadeReceiverConditionalReassignmentIsConservative(t *testing.T) {
+	src := `using Microsoft.EntityFrameworkCore.Infrastructure;
+
+class Repo {
+    void Run(MyDbContext db, FakeRunner fake, bool flag) {
+        DatabaseFacade database = db.Database;
+        if (flag) {
+            database = fake;
+        }
+        database.ExecuteSqlRaw("DELETE FROM temp_data WHERE created_at < NOW()");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 0 {
+		t.Fatalf("expected 0 for conditional receiver reassignment, got %d: %+v", len(stmts), stmts)
+	}
+}
+
+func TestDatabaseFacadeReceiverNestedScopeDoesNotLeak(t *testing.T) {
+	src := `using Microsoft.EntityFrameworkCore.Infrastructure;
+
+class Repo {
+    void Run(MyDbContext db) {
+        {
+            DatabaseFacade database = db.Database;
+        }
+        database.ExecuteSqlRaw("DELETE FROM temp_data WHERE created_at < NOW()");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 0 {
+		t.Fatalf("expected 0 for nested-scope facade local, got %d: %+v", len(stmts), stmts)
 	}
 }
 
@@ -347,6 +537,115 @@ func TestEmptyDirectory(t *testing.T) {
 	}
 }
 
+func TestNoCSharpFilesDoesNotRequireDotnet(t *testing.T) {
+	tmpDir := t.TempDir()
+	textFile := filepath.Join(tmpDir, "plain.txt")
+	if err := os.WriteFile(textFile, []byte(`class Plain { string Name => "not sql"; }`), 0644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	s := &Scanner{DotnetPath: "missing-dotnet-for-test"}
+	stmts, err := scanner.Collect(s.Scan(context.Background(), []string{tmpDir}))
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+	if len(stmts) != 0 {
+		t.Fatalf("expected 0 statements, got %d: %+v", len(stmts), stmts)
+	}
+}
+
+func TestCollectCandidatesReturnsAllCSharpFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	csFile := filepath.Join(tmpDir, "plain.cs")
+	if err := os.WriteFile(csFile, []byte(`class Plain { string Name => "not sql"; }`), 0644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	candidates, err := collectCandidates(context.Background(), []string{tmpDir})
+	if err != nil {
+		t.Fatalf("collectCandidates() error = %v", err)
+	}
+	if len(candidates) != 1 || candidates[0] != csFile {
+		t.Fatalf("expected C# candidate %q, got %+v", csFile, candidates)
+	}
+}
+
+func TestCachedRoslynProjectMaterializesEmbeddedFiles(t *testing.T) {
+	cacheRoot := t.TempDir()
+	oldUserCacheDir := userCacheDir
+	userCacheDir = func() (string, error) { return cacheRoot, nil }
+	t.Cleanup(func() { userCacheDir = oldUserCacheDir })
+
+	project, err := (&Scanner{}).roslynProject()
+	if err != nil {
+		t.Fatalf("roslynProject() error = %v", err)
+	}
+	if !project.cached {
+		t.Fatal("expected embedded Roslyn project to use cache")
+	}
+	if !strings.HasPrefix(project.projectPath, cacheRoot) {
+		t.Fatalf("expected project path under cache root %q, got %q", cacheRoot, project.projectPath)
+	}
+	if _, err := os.Stat(project.projectPath); err != nil {
+		t.Fatalf("expected cached project file: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(project.projectPath), "Program.cs")); err != nil {
+		t.Fatalf("expected cached program file: %v", err)
+	}
+
+	second, err := (&Scanner{}).roslynProject()
+	if err != nil {
+		t.Fatalf("second roslynProject() error = %v", err)
+	}
+	if second.projectPath != project.projectPath {
+		t.Fatalf("expected stable cache path, got %q then %q", project.projectPath, second.projectPath)
+	}
+	if !strings.HasSuffix(project.executablePath, filepath.Join("publish", cachedExtractorName())) {
+		t.Fatalf("expected cached executable under publish dir, got %q", project.executablePath)
+	}
+}
+
+func TestPathForDotnetConvertsWSLPathsForWindowsDotnet(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("WSL path conversion only applies on linux")
+	}
+	if got := pathForDotnet("/mnt/c/Program Files/dotnet/dotnet.exe", "/mnt/c/users/eitam/cache/project.csproj"); got != `C:\users\eitam\cache\project.csproj` {
+		t.Fatalf("unexpected converted path: %q", got)
+	}
+}
+
+func TestCSharpFilesRequireDotnet(t *testing.T) {
+	src := `using Microsoft.EntityFrameworkCore;
+
+class Repo {
+    void Run(MyDbContext db) {
+        db.Database.ExecuteSqlRaw("SELECT 1");
+    }
+}`
+	tmpDir := t.TempDir()
+	if os.Getenv("VALK_DOTNET_PATH") != "" {
+		var err error
+		tmpDir, err = os.MkdirTemp(".", ".csharp-test-*")
+		if err != nil {
+			t.Fatalf("create local temp dir: %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	}
+	csFile := filepath.Join(tmpDir, "test.cs")
+	if err := os.WriteFile(csFile, []byte(src), 0644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	s := &Scanner{DotnetPath: "missing-dotnet-for-test"}
+	_, err := scanner.Collect(s.Scan(context.Background(), []string{tmpDir}))
+	if err == nil {
+		t.Fatal("expected missing dotnet error")
+	}
+	if !strings.Contains(err.Error(), ".NET SDK is required") {
+		t.Fatalf("expected .NET SDK error, got %v", err)
+	}
+}
+
 func TestNonSQLStringSkipped(t *testing.T) {
 	src := `class Repo {
     void Run(MyDbContext db) {
@@ -403,5 +702,327 @@ func TestConcatenationWithVariable(t *testing.T) {
 	want := "SELECT id, name FROM users WHERE active = true LIMIT 10"
 	if stmts[0].SQL != want {
 		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}
+
+func TestFromSqlRawExtractedFromDbSet(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        var users = db.Users.FromSqlRaw("SELECT * FROM users WHERE active = true").ToList();
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d: %+v", len(stmts), stmts)
+	}
+	want := "SELECT * FROM users WHERE active = true"
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}
+
+func TestSqlQueryInterpolatedExtractedFromDatabase(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db, int id) {
+        var ids = db.Database.SqlQueryInterpolated<int>($"SELECT id FROM users WHERE id = {id}").ToList();
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1, got %d: %+v", len(stmts), stmts)
+	}
+	want := "SELECT id FROM users WHERE id = $1"
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}
+
+func TestRawEFSQLSelectForUpdateTriggersRule(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        db.Users.FromSqlRaw("SELECT id FROM users FOR UPDATE").ToList();
+    }
+}`
+	stmts := scanCS(t, src)
+	findingsByRule := scannertest.CollectFindingsByRule(t, stmts)
+	if findingsByRule["VG006"] == 0 {
+		t.Fatalf("expected VG006 from raw EF SQL FOR UPDATE without WHERE, got %+v (stmts: %+v)", findingsByRule, stmts)
+	}
+}
+
+func TestLINQChainsGenerateSyntheticSQLAndTriggerRules(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        db.Users.Include(u => u.Orders).ToList();
+        db.Users.Where(u => u.Email.Contains("@gmail.com")).ToList();
+        db.Logs.Include(l => l.User).Select(l => new { l.Id, l.Message }).ToList();
+        db.Users.ExecuteDelete();
+        db.Users.ExecuteUpdate(s => s.SetProperty(u => u.Active, false));
+    }
+}`
+	stmts := scanCS(t, src)
+	findingsByRule := scannertest.CollectFindingsByRule(t, stmts)
+	for _, ruleID := range []string{"VG001", "VG002", "VG003", "VG004", "VG005"} {
+		if findingsByRule[ruleID] == 0 {
+			t.Fatalf("expected %s from C# synthetic LINQ chains, got none (findings: %+v, stmts: %+v)", ruleID, findingsByRule, stmts)
+		}
+	}
+	if !scannertest.HasSQLContaining(stmts, "/* valk-guard:synthetic csharp-efcore */ SELECT * FROM Users LEFT JOIN Orders ON 1=1") {
+		t.Fatalf("expected synthetic SELECT with include join, got %+v", stmts)
+	}
+	if !scannertest.HasSQLContaining(stmts, "Email LIKE '%@gmail.com%'") {
+		t.Fatalf("expected synthetic LIKE predicate, got %+v", stmts)
+	}
+}
+
+func TestLINQChainsFromStandaloneWhereGenerateSyntheticSQL(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        db.Users.Where(u => u.Email.Contains("@gmail.com")).ToList();
+    }
+}`
+	stmts := scanCS(t, src)
+	if !scannertest.HasSQLContaining(stmts, "Email LIKE '%@gmail.com%'") {
+		t.Fatalf("expected standalone Where synthetic LIKE predicate, got %+v", stmts)
+	}
+}
+
+func TestLINQCountAndAnyAvoidSelectStarAndUnboundedFindings(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        db.Users.Count();
+        db.Users.Any();
+    }
+}`
+	stmts := scanCS(t, src)
+	findingsByRule := scannertest.CollectFindingsByRule(t, stmts)
+	if findingsByRule["VG001"] != 0 || findingsByRule["VG004"] != 0 {
+		t.Fatalf("expected Count/Any chains to avoid VG001/VG004, got %+v (stmts: %+v)", findingsByRule, stmts)
+	}
+	if !scannertest.HasSQLContaining(stmts, "SELECT COUNT(*) FROM Users") {
+		t.Fatalf("expected Count synthetic aggregate SQL, got %+v", stmts)
+	}
+	if !scannertest.HasSQLContaining(stmts, "SELECT 1 FROM Users LIMIT 1") {
+		t.Fatalf("expected Any synthetic bounded SQL, got %+v", stmts)
+	}
+}
+
+func TestDbSetQualifiedGenericTypeUsesRightmostTableName(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        db.Set<My.App.User>().Count();
+    }
+}`
+	stmts := scanCS(t, src)
+	if !scannertest.HasSQLContaining(stmts, "SELECT COUNT(*) FROM User") {
+		t.Fatalf("expected qualified generic DbSet table to use rightmost type name, got %+v", stmts)
+	}
+}
+
+func TestLINQILikeGeneratesILikePredicate(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        db.Users.Where(u => EF.Functions.ILike(u.Email, "%@gmail.com")).ToList();
+    }
+}`
+	stmts := scanCS(t, src)
+	if !scannertest.HasSQLContaining(stmts, "Email ILIKE '%@gmail.com'") {
+		t.Fatalf("expected ILike synthetic predicate, got %+v", stmts)
+	}
+}
+
+func TestUserDefinedILikeIsNotRenderedAsILIKE(t *testing.T) {
+	src := `class Helpers {
+    public static bool ILike(string a, string b) { return false; }
+}
+class Repo {
+    void Run(MyDbContext db) {
+        db.Users.Where(u => Helpers.ILike(u.Email, "%@gmail.com")).ToList();
+    }
+}`
+	stmts := scanCS(t, src)
+	if scannertest.HasSQLContaining(stmts, "ILIKE") {
+		t.Fatalf("expected user-defined ILike helper to not produce ILIKE, got %+v", stmts)
+	}
+	if scannertest.HasSQLContaining(stmts, "LIKE '%@gmail.com'") {
+		t.Fatalf("expected user-defined ILike helper to not produce LIKE either, got %+v", stmts)
+	}
+}
+
+func TestWhereThenAnyPredicatesUseUniquePlaceholders(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db, int userId, string name) {
+        db.Users.Where(u => u.Id == userId).Any(u => u.Name == name);
+    }
+}`
+	stmts := scanCS(t, src)
+	if !scannertest.HasSQLContaining(stmts, "Id = $1") {
+		t.Fatalf("expected first predicate to bind $1, got %+v", stmts)
+	}
+	if !scannertest.HasSQLContaining(stmts, "Name = $2") {
+		t.Fatalf("expected terminal Any predicate to advance to $2, got %+v", stmts)
+	}
+	if scannertest.HasSQLContaining(stmts, "Name = $1") {
+		t.Fatalf("expected terminal Any predicate to not collide on $1, got %+v", stmts)
+	}
+}
+
+func TestWhereThenAllPredicatesUseUniquePlaceholders(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db, int userId, bool active) {
+        db.Users.Where(u => u.Id == userId).All(u => u.Active == active);
+    }
+}`
+	stmts := scanCS(t, src)
+	if !scannertest.HasSQLContaining(stmts, "Id = $1") {
+		t.Fatalf("expected first predicate to bind $1, got %+v", stmts)
+	}
+	if !scannertest.HasSQLContaining(stmts, "Active = $2") {
+		t.Fatalf("expected terminal All predicate to advance to $2, got %+v", stmts)
+	}
+}
+
+func TestLINQDeleteAndUpdateIgnoreIncludeTargets(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        db.Users.Include(u => u.Roles).ExecuteDelete();
+        db.Users.Include(u => u.Profile).ExecuteUpdate(s => s.SetProperty(u => u.Active, false));
+    }
+}`
+	stmts := scanCS(t, src)
+	if scannertest.HasSQLContaining(stmts, "USING Roles") || scannertest.HasSQLContaining(stmts, "FROM Profile") {
+		t.Fatalf("expected Include targets to be ignored for write SQL, got %+v", stmts)
+	}
+	if !scannertest.HasSQLContaining(stmts, "DELETE FROM Users") {
+		t.Fatalf("expected delete synthetic SQL, got %+v", stmts)
+	}
+	if !scannertest.HasSQLContaining(stmts, "UPDATE Users SET Active = $1") {
+		t.Fatalf("expected update synthetic SQL with placeholder set clause, got %+v", stmts)
+	}
+}
+
+func TestLINQDeleteAndUpdatePreserveExplicitJoinTargets(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        db.Users.Join(db.Roles, u => u.Id, r => r.UserId, (u, r) => u).ExecuteDelete();
+        db.Users.Join(db.Profiles, u => u.Id, p => p.UserId, (u, p) => u).ExecuteUpdate(s => s.SetProperty(u => u.Active, false));
+    }
+}`
+	stmts := scanCS(t, src)
+	if !scannertest.HasSQLContaining(stmts, "DELETE FROM Users USING Roles") {
+		t.Fatalf("expected delete synthetic SQL to preserve explicit join target, got %+v", stmts)
+	}
+	if !scannertest.HasSQLContaining(stmts, "UPDATE Users SET Active = $1 FROM Profiles") {
+		t.Fatalf("expected update synthetic SQL to preserve explicit join target, got %+v", stmts)
+	}
+}
+
+func TestLINQWhereAndTakeAvoidMissingWhereAndLimitFindings(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db) {
+        db.Users.Where(u => u.Active == true).Take(25).ToList();
+        db.Users.Where(u => u.Id == 7).ExecuteDelete();
+        db.Users.Where(u => u.Id == 8).ExecuteUpdate(s => s.SetProperty(u => u.Active, false));
+    }
+}`
+	stmts := scanCS(t, src)
+	findingsByRule := scannertest.CollectFindingsByRule(t, stmts)
+	if findingsByRule["VG002"] != 0 || findingsByRule["VG003"] != 0 || findingsByRule["VG004"] != 0 {
+		t.Fatalf("expected filtered/taken chains to avoid VG002/VG003/VG004, got %+v (stmts: %+v)", findingsByRule, stmts)
+	}
+	if !scannertest.HasSQLContaining(stmts, "WHERE Active = TRUE LIMIT 25") {
+		t.Fatalf("expected synthesized WHERE and LIMIT, got %+v", stmts)
+	}
+}
+
+func TestRejectsDatabaseNamedNonFacadeReceiver(t *testing.T) {
+	src := `class FakeRunner {
+    public void ExecuteSqlRaw(string sql) {}
+}
+
+class Repo {
+    void Run(FakeRunner database) {
+        database.ExecuteSqlRaw("DELETE FROM temp_data WHERE created_at < NOW()");
+    }
+}`
+	stmts := scanCS(t, src)
+	if len(stmts) != 0 {
+		t.Fatalf("expected 0 for non-DatabaseFacade parameter named database, got %d: %+v", len(stmts), stmts)
+	}
+}
+
+func TestLINQParityFeatureClauses(t *testing.T) {
+	src := `class Repo {
+    void Run(MyDbContext db, int[] ids, int minId) {
+        db.Users
+            .Distinct()
+            .Where(u => ids.Contains(u.Id))
+            .OrderBy(u => u.Email)
+            .ThenByDescending(u => u.Id)
+            .GroupBy(u => u.Email)
+            .Where(u => u.Id > minId)
+            .Skip(20)
+            .Take(10)
+            .ToList();
+        db.Users.Where(u => !ids.Contains(u.Id)).Take(1).ToList();
+        db.Orders.Sum(o => o.Total);
+    }
+}`
+	stmts := scanCS(t, src)
+	for _, want := range []string{
+		"SELECT DISTINCT * FROM Users",
+		"WHERE Id IN ($1, $2, $3)",
+		"GROUP BY Email HAVING Id > $4",
+		"ORDER BY Email ASC, Id DESC LIMIT 10 OFFSET 20",
+		"WHERE NOT (Id IN ($1, $2, $3)) LIMIT 1",
+		"SELECT SUM(Total) FROM Orders",
+	} {
+		if !scannertest.HasSQLContaining(stmts, want) {
+			t.Fatalf("expected synthetic SQL containing %q, got %+v", want, stmts)
+		}
+	}
+}
+
+func TestLINQTableMappingResolution(t *testing.T) {
+	src := `using System.ComponentModel.DataAnnotations.Schema;
+
+[Table("app_users", Schema = "crm")]
+class User {}
+class Order {}
+class MyDbContext { public object Users { get; set; } public object Orders { get; set; } }
+class Repo {
+    void Configure(ModelBuilder modelBuilder) {
+        modelBuilder.Entity<Order>().ToTable("sales_orders");
+    }
+    void Run(MyDbContext db) {
+        db.Set<User>().Count();
+        db.Set<Order>().Count();
+    }
+}`
+	stmts := scanCS(t, src)
+	if !scannertest.HasSQLContaining(stmts, "SELECT COUNT(*) FROM crm.app_users") {
+		t.Fatalf("expected Table attribute mapping, got %+v", stmts)
+	}
+	if !scannertest.HasSQLContaining(stmts, "SELECT COUNT(*) FROM sales_orders") {
+		t.Fatalf("expected ToTable mapping, got %+v", stmts)
+	}
+}
+
+func TestRunRoslynExtractorTimeout(t *testing.T) {
+	t.Setenv("VALK_FAKE_DOTNET", "sleep")
+	s := &Scanner{DotnetPath: os.Args[0], ProjectPath: "fake.csproj", Timeout: 20 * time.Millisecond}
+	ctx := context.Background()
+	_, err := s.runRoslynExtractor(ctx, []string{"fake.cs"})
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+}
+
+func TestRunRoslynExtractorMalformedJSON(t *testing.T) {
+	t.Setenv("VALK_FAKE_DOTNET", "malformed-json")
+	s := &Scanner{DotnetPath: os.Args[0], ProjectPath: "fake.csproj", Timeout: 10 * time.Second}
+	_, err := s.runRoslynExtractor(context.Background(), []string{"fake.cs"})
+	if err == nil || !strings.Contains(err.Error(), "decode C# Roslyn extractor output") {
+		t.Fatalf("expected malformed JSON error, got %v", err)
 	}
 }

--- a/internal/scanner/engines.go
+++ b/internal/scanner/engines.go
@@ -11,6 +11,7 @@ var knownEngines = [...]Engine{
 	EngineGo,
 	EngineGoqu,
 	EngineSQLAlchemy,
+	EngineCSharp,
 }
 
 // KnownEngines returns a copy of all registered built-in engine identifiers.

--- a/internal/scanner/go_scanner.go
+++ b/internal/scanner/go_scanner.go
@@ -39,31 +39,7 @@ type GoScanner struct{}
 
 var errGoScannerStop = errors.New("go scanner stop")
 
-// sqlKeywordSet maps known SQL statement-opening keywords to an empty struct
-// for O(1) lookup. The looksLikeSQL function extracts the first word from the
-// input and checks for membership here instead of iterating a slice.
-var sqlKeywordSet = map[string]struct{}{
-	"SELECT":   {},
-	"INSERT":   {},
-	"UPDATE":   {},
-	"DELETE":   {},
-	"CREATE":   {},
-	"DROP":     {},
-	"ALTER":    {},
-	"TRUNCATE": {},
-	"WITH":     {},
-	"GRANT":    {},
-	"REVOKE":   {},
-	"BEGIN":    {},
-	"COMMIT":   {},
-	"ROLLBACK": {},
-	"SET":      {},
-	"COPY":     {},
-	"VACUUM":   {},
-	"ANALYZE":  {},
-	"EXPLAIN":  {},
-	"MERGE":    {},
-}
+// SQL keyword set and LooksLikeSQL are defined in sql_heuristic.go.
 
 // Scan walks the given paths, finds .go files, and streams SQL strings.
 func (s *GoScanner) Scan(ctx context.Context, paths []string) iter.Seq2[SQLStatement, error] {
@@ -157,39 +133,5 @@ func findSQLArg(call *ast.CallExpr, spec dbMethodSpec) string {
 	return ExtractStringLiteral(lit)
 }
 
-// looksLikeSQL reports whether the string appears to be a SQL statement
-// by checking for common starting keywords or comments.
-// It extracts only the first word (letters A-Z) and performs an O(1) map
-// lookup instead of a linear scan over all keywords.
-func looksLikeSQL(s string) bool {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return false
-	}
-	// Allow SQL line/block comments as valid statement starts.
-	if strings.HasPrefix(s, "--") || strings.HasPrefix(s, "/*") {
-		return true
-	}
-	upper := strings.ToUpper(s)
-	// Extract the leading alphabetic word (SQL keywords are all letters).
-	end := 0
-	for end < len(upper) && upper[end] >= 'A' && upper[end] <= 'Z' {
-		end++
-	}
-	if end == 0 {
-		return false
-	}
-	// Ensure the keyword is not a prefix of a longer identifier (e.g. "SELECTOR").
-	if end < len(upper) && isIdentChar(upper[end]) {
-		return false
-	}
-	_, ok := sqlKeywordSet[upper[:end]]
-	return ok
-}
-
-func isIdentChar(c byte) bool {
-	return (c >= 'a' && c <= 'z') ||
-		(c >= 'A' && c <= 'Z') ||
-		(c >= '0' && c <= '9') ||
-		c == '_'
-}
+// looksLikeSQL delegates to the shared LooksLikeSQL in sql_heuristic.go.
+func looksLikeSQL(s string) bool { return LooksLikeSQL(s) }

--- a/internal/scanner/goqu/goqu_scanner.go
+++ b/internal/scanner/goqu/goqu_scanner.go
@@ -42,6 +42,7 @@ var goquBuilderMethods = map[string]struct{}{
 	"LeftJoin":      {},
 	"RightJoin":     {},
 	"FullJoin":      {},
+	"CrossJoin":     {},
 	"Update":        {},
 	"Delete":        {},
 	"Set":           {},
@@ -270,9 +271,15 @@ type chainParts struct {
 	hasSelect  bool
 	joins      []joinPart
 	predicates []string
+	having     []string
+	orderBy    []string
+	groupBy    []string
 	hasWhere   bool
 	hasLimit   bool
 	limitVal   string
+	hasOffset  bool
+	offsetVal  string
+	distinct   bool
 	forUpdate  bool
 }
 
@@ -280,12 +287,14 @@ type chainParts struct {
 type joinPart struct {
 	joinType string
 	table    string
+	on       string
 }
 
 // collectChainParts walks the method chain and populates a chainParts struct.
 func collectChainParts(chain []methodCall, alias string) chainParts {
 	cp := chainParts{
-		limitVal: "1",
+		limitVal:  "1",
+		offsetVal: "1",
 	}
 
 	if len(chain) == 0 || len(chain[0].Args) == 0 {
@@ -293,6 +302,7 @@ func collectChainParts(chain []methodCall, alias string) chainParts {
 	}
 	cp.table = tableNameFromExpr(chain[0].Args[0], alias, "synthetic_table")
 
+	nextBind := 1
 	for _, link := range chain[1:] {
 		switch link.Name {
 		case "Select":
@@ -300,7 +310,15 @@ func collectChainParts(chain []methodCall, alias string) chainParts {
 			if cols := extractSelectColumns(link.Args, alias); len(cols) > 0 {
 				cp.columns = cols
 			}
-		case "Join", "InnerJoin", "LeftJoin", "RightJoin", "FullJoin":
+		case "Distinct":
+			cp.distinct = true
+		case "Order":
+			cp.orderBy = append(cp.orderBy, extractOrderBy(link.Args, alias)...)
+		case "GroupBy":
+			cp.groupBy = append(cp.groupBy, extractColumns(link.Args, alias)...)
+		case "Having":
+			cp.having = append(cp.having, extractPredicates(link.Args, alias, &nextBind)...)
+		case "Join", "InnerJoin", "LeftJoin", "RightJoin", "FullJoin", "CrossJoin":
 			jt := "JOIN"
 			switch link.Name {
 			case "LeftJoin":
@@ -309,15 +327,21 @@ func collectChainParts(chain []methodCall, alias string) chainParts {
 				jt = "RIGHT JOIN"
 			case "FullJoin":
 				jt = "FULL JOIN"
+			case "CrossJoin":
+				jt = "CROSS JOIN"
 			}
 			table := "synthetic_join"
 			if len(link.Args) > 0 {
 				table = tableNameFromExpr(link.Args[0], alias, "synthetic_join")
 			}
-			cp.joins = append(cp.joins, joinPart{joinType: jt, table: table})
+			on := "1=1"
+			if len(link.Args) > 1 {
+				on = joinOnFromExpr(link.Args[1], alias)
+			}
+			cp.joins = append(cp.joins, joinPart{joinType: jt, table: table, on: on})
 		case "Where":
 			cp.hasWhere = true
-			conds := extractPredicates(link.Args, alias)
+			conds := extractPredicates(link.Args, alias, &nextBind)
 			if len(conds) == 0 {
 				conds = []string{"1=1"}
 			}
@@ -325,6 +349,9 @@ func collectChainParts(chain []methodCall, alias string) chainParts {
 		case "Limit":
 			cp.hasLimit = true
 			cp.limitVal = limitFromArgs(link.Args)
+		case "Offset":
+			cp.hasOffset = true
+			cp.offsetVal = limitFromArgs(link.Args)
 		case "ForUpdate":
 			cp.forUpdate = true
 		}
@@ -344,15 +371,35 @@ func renderSelect(cp *chainParts) string {
 		columns = []string{"*"}
 	}
 
-	sql := fmt.Sprintf("SELECT %s FROM %s", strings.Join(columns, ", "), cp.table)
+	distinct := ""
+	if cp.distinct {
+		distinct = "DISTINCT "
+	}
+	sql := fmt.Sprintf("SELECT %s%s FROM %s", distinct, strings.Join(columns, ", "), cp.table)
 	for _, j := range cp.joins {
-		sql += fmt.Sprintf(" %s %s ON 1=1", j.joinType, j.table)
+		if j.joinType == "CROSS JOIN" {
+			sql += fmt.Sprintf(" %s %s", j.joinType, j.table)
+		} else {
+			sql += fmt.Sprintf(" %s %s ON %s", j.joinType, j.table, j.on)
+		}
 	}
 	if cp.hasWhere && len(cp.predicates) > 0 {
 		sql += " WHERE " + strings.Join(cp.predicates, " AND ")
 	}
+	if len(cp.groupBy) > 0 {
+		sql += " GROUP BY " + strings.Join(cp.groupBy, ", ")
+	}
+	if len(cp.having) > 0 {
+		sql += " HAVING " + strings.Join(cp.having, " AND ")
+	}
+	if len(cp.orderBy) > 0 {
+		sql += " ORDER BY " + strings.Join(cp.orderBy, ", ")
+	}
 	if cp.hasLimit {
 		sql += " LIMIT " + cp.limitVal
+	}
+	if cp.hasOffset {
+		sql += " OFFSET " + cp.offsetVal
 	}
 	if cp.forUpdate {
 		sql += " FOR UPDATE"
@@ -406,7 +453,7 @@ func renderDelete(cp *chainParts) string {
 func extractSelectColumns(args []ast.Expr, alias string) []string {
 	columns := make([]string, 0, len(args))
 	for _, arg := range args {
-		col := columnNameFromExpr(arg, alias, "")
+		col := selectExprFromExpr(arg, alias)
 		if col == "" {
 			continue
 		}
@@ -418,13 +465,62 @@ func extractSelectColumns(args []ast.Expr, alias string) []string {
 	return columns
 }
 
+// extractColumns converts AST expressions into SQL column identifiers.
+func extractColumns(args []ast.Expr, alias string) []string {
+	columns := make([]string, 0, len(args))
+	for _, arg := range args {
+		if col := columnNameFromExpr(arg, alias, ""); col != "" {
+			columns = append(columns, col)
+		}
+	}
+	return columns
+}
+
+// extractOrderBy converts goqu order expressions into ORDER BY fragments.
+func extractOrderBy(args []ast.Expr, alias string) []string {
+	orders := make([]string, 0, len(args))
+	for _, arg := range args {
+		col := columnNameFromExpr(arg, alias, "")
+		if col == "" {
+			continue
+		}
+		direction := "ASC"
+		if call, ok := arg.(*ast.CallExpr); ok {
+			if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Desc" {
+				direction = "DESC"
+			}
+		}
+		orders = append(orders, col+" "+direction)
+	}
+	return orders
+}
+
+// selectExprFromExpr resolves projections, including goqu aggregate functions.
+func selectExprFromExpr(expr ast.Expr, alias string) string {
+	if call, ok := expr.(*ast.CallExpr); ok {
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+			if x, ok := sel.X.(*ast.Ident); ok && x.Name == alias {
+				switch strings.ToUpper(sel.Sel.Name) {
+				case "SUM", "MIN", "MAX", "AVG", "COUNT":
+					col := "*"
+					if len(call.Args) > 0 {
+						col = columnNameFromExpr(call.Args[0], alias, "synthetic_col")
+					}
+					return strings.ToUpper(sel.Sel.Name) + "(" + col + ")"
+				}
+			}
+		}
+	}
+	return columnNameFromExpr(expr, alias, "")
+}
+
 // extractPredicates converts a slice of AST expressions from a goqu Where()
 // call into SQL predicate strings, skipping any arguments that cannot be
 // resolved to a predicate.
-func extractPredicates(args []ast.Expr, alias string) []string {
+func extractPredicates(args []ast.Expr, alias string, nextBind *int) []string {
 	var predicates []string
 	for _, arg := range args {
-		p := predicateFromExpr(arg, alias)
+		p := predicateFromExpr(arg, alias, nextBind)
 		if p != "" {
 			predicates = append(predicates, p)
 		}
@@ -436,7 +532,7 @@ func extractPredicates(args []ast.Expr, alias string) []string {
 // predicate (such as goqu.C("col").Eq(val) or a goqu.Ex{} composite literal)
 // into a SQL condition string. Returns "" if the expression cannot be
 // recognized as a predicate.
-func predicateFromExpr(expr ast.Expr, alias string) string {
+func predicateFromExpr(expr ast.Expr, alias string, nextBind *int) string {
 	switch e := expr.(type) {
 	case *ast.CallExpr:
 		sel, ok := e.Fun.(*ast.SelectorExpr)
@@ -444,24 +540,40 @@ func predicateFromExpr(expr ast.Expr, alias string) string {
 			return ""
 		}
 
+		if x, ok := sel.X.(*ast.Ident); ok && x.Name == alias && (sel.Sel.Name == "Or" || sel.Sel.Name == "And") {
+			parts := extractPredicates(e.Args, alias, nextBind)
+			if len(parts) == 0 {
+				return ""
+			}
+			joiner := " AND "
+			if sel.Sel.Name == "Or" {
+				joiner = " OR "
+			}
+			return "(" + strings.Join(parts, joiner) + ")"
+		}
+
 		col := columnNameFromExpr(sel.X, alias, "synthetic_col")
 		switch sel.Sel.Name {
 		case "Like":
-			return fmt.Sprintf("%s LIKE %s", col, sqlValue(firstArg(e.Args)))
+			return fmt.Sprintf("%s LIKE %s", col, sqlValue(firstArg(e.Args), nextBind))
 		case "ILike":
-			return fmt.Sprintf("%s ILIKE %s", col, sqlValue(firstArg(e.Args)))
+			return fmt.Sprintf("%s ILIKE %s", col, sqlValue(firstArg(e.Args), nextBind))
 		case "Eq":
-			return fmt.Sprintf("%s = %s", col, sqlValue(firstArg(e.Args)))
+			return fmt.Sprintf("%s = %s", col, sqlValue(firstArg(e.Args), nextBind))
 		case "Neq":
-			return fmt.Sprintf("%s <> %s", col, sqlValue(firstArg(e.Args)))
+			return fmt.Sprintf("%s <> %s", col, sqlValue(firstArg(e.Args), nextBind))
 		case "Gt":
-			return fmt.Sprintf("%s > %s", col, sqlValue(firstArg(e.Args)))
+			return fmt.Sprintf("%s > %s", col, sqlValue(firstArg(e.Args), nextBind))
 		case "Gte":
-			return fmt.Sprintf("%s >= %s", col, sqlValue(firstArg(e.Args)))
+			return fmt.Sprintf("%s >= %s", col, sqlValue(firstArg(e.Args), nextBind))
 		case "Lt":
-			return fmt.Sprintf("%s < %s", col, sqlValue(firstArg(e.Args)))
+			return fmt.Sprintf("%s < %s", col, sqlValue(firstArg(e.Args), nextBind))
 		case "Lte":
-			return fmt.Sprintf("%s <= %s", col, sqlValue(firstArg(e.Args)))
+			return fmt.Sprintf("%s <= %s", col, sqlValue(firstArg(e.Args), nextBind))
+		case "In":
+			return fmt.Sprintf("%s IN (%s)", col, bindListFromExpr(firstArg(e.Args), nextBind))
+		case "NotIn":
+			return fmt.Sprintf("%s NOT IN (%s)", col, bindListFromExpr(firstArg(e.Args), nextBind))
 		}
 
 	case *ast.CompositeLit:
@@ -473,7 +585,7 @@ func predicateFromExpr(expr ast.Expr, alias string) string {
 			}
 			key := literalOrIdent(kv.Key)
 			key = safeIdent(key, "synthetic_col")
-			predicates = append(predicates, fmt.Sprintf("%s = %s", key, sqlValue(kv.Value)))
+			predicates = append(predicates, fmt.Sprintf("%s = %s", key, sqlValue(kv.Value, nextBind)))
 		}
 		if len(predicates) > 0 {
 			return strings.Join(predicates, " AND ")
@@ -481,6 +593,52 @@ func predicateFromExpr(expr ast.Expr, alias string) string {
 	}
 
 	return ""
+}
+
+// joinOnFromExpr converts goqu.On(...) expressions into a SQL ON predicate.
+func joinOnFromExpr(expr ast.Expr, alias string) string {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return "1=1"
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "1=1"
+	}
+	if x, ok := sel.X.(*ast.Ident); !ok || x.Name != alias || sel.Sel.Name != "On" {
+		return "1=1"
+	}
+	var parts []string
+	for _, arg := range call.Args {
+		if lit, ok := arg.(*ast.CompositeLit); ok {
+			for _, elt := range lit.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				left := safeIdent(literalOrIdent(kv.Key), "synthetic_col")
+				right := columnNameFromExpr(kv.Value, alias, "synthetic_col")
+				parts = append(parts, left+" = "+right)
+			}
+		}
+	}
+	if len(parts) == 0 {
+		return "1=1"
+	}
+	return strings.Join(parts, " AND ")
+}
+
+// bindListFromExpr renders a PostgreSQL-style bind list for IN predicates.
+func bindListFromExpr(expr ast.Expr, nextBind *int) string {
+	arity := 3
+	if lit, ok := expr.(*ast.CompositeLit); ok && len(lit.Elts) > 0 {
+		arity = len(lit.Elts)
+	}
+	values := make([]string, 0, arity)
+	for i := 0; i < arity; i++ {
+		values = append(values, sqlValue(&ast.Ident{Name: "synthetic"}, nextBind))
+	}
+	return strings.Join(values, ", ")
 }
 
 // tableNameFromExpr resolves an AST expression to a safe SQL table name
@@ -582,8 +740,8 @@ func literalOrIdent(expr ast.Expr) string {
 // sqlValue converts an AST expression to a SQL value literal suitable for
 // embedding in a synthetic query. String literals are single-quoted, numeric
 // literals are emitted as-is, boolean/nil identifiers are mapped to SQL
-// keywords, and all other expressions are replaced with 'synthetic_value'.
-func sqlValue(expr ast.Expr) string {
+// keywords, and all other expressions are replaced with numbered binds.
+func sqlValue(expr ast.Expr, nextBind *int) string {
 	if expr == nil {
 		return "NULL"
 	}
@@ -615,7 +773,9 @@ func sqlValue(expr ast.Expr) string {
 		}
 	}
 
-	return "'synthetic_value'"
+	placeholder := fmt.Sprintf("$%d", *nextBind)
+	*nextBind++
+	return placeholder
 }
 
 // limitFromArgs extracts the LIMIT value from the AST arguments of a goqu

--- a/internal/scanner/goqu/goqu_scanner_test.go
+++ b/internal/scanner/goqu/goqu_scanner_test.go
@@ -45,7 +45,7 @@ func queries() {
 		t.Fatalf("expected raw goqu.L SQL to be extracted")
 	}
 
-	if !scannertest.HasSQLContaining(stmts, "/* valk-guard:synthetic goqu-ast */ SELECT * FROM users JOIN orders ON 1=1") {
+	if !scannertest.HasSQLContaining(stmts, "/* valk-guard:synthetic goqu-ast */ SELECT * FROM users JOIN orders ON users.id = orders.uid") {
 		t.Fatalf("expected synthetic SQL with JOIN and SELECT * from builder chain, got %+v", stmts)
 	}
 }
@@ -86,7 +86,7 @@ func queries() {
 		}
 	}
 
-	if !scannertest.HasSQLContaining(stmts, "LEFT JOIN orders ON 1=1") {
+	if !scannertest.HasSQLContaining(stmts, "LEFT JOIN orders ON users.id = orders.uid") {
 		t.Fatalf("expected synthetic SQL to preserve join structure, got %+v", stmts)
 	}
 	if !scannertest.HasSQLContaining(stmts, "email LIKE '%@gmail.com'") {
@@ -217,10 +217,10 @@ func queries() {
 		t.Fatal("expected statements from multi-join chain, got 0")
 	}
 
-	if !scannertest.HasSQLContaining(stmts, "JOIN orders ON 1=1") {
+	if !scannertest.HasSQLContaining(stmts, "JOIN orders ON users.id = orders.uid") {
 		t.Fatalf("expected first JOIN in synthetic SQL, got %+v", stmts)
 	}
-	if !scannertest.HasSQLContaining(stmts, "JOIN items ON 1=1") {
+	if !scannertest.HasSQLContaining(stmts, "JOIN items ON orders.id = items.oid") {
 		t.Fatalf("expected second JOIN in synthetic SQL, got %+v", stmts)
 	}
 }
@@ -255,7 +255,7 @@ func queries() {
 	if len(stmts) != 1 {
 		t.Fatalf("expected 1 synthetic statement for ToSQL() chain, got %d: %+v", len(stmts), stmts)
 	}
-	if !scannertest.HasSQLContaining(stmts, "LEFT JOIN orders ON 1=1") {
+	if !scannertest.HasSQLContaining(stmts, "LEFT JOIN orders ON orders.user_id = users.id") {
 		t.Fatalf("expected LEFT JOIN in synthetic SQL, got %+v", stmts)
 	}
 }
@@ -310,5 +310,56 @@ func TestGoquScannerEmptyDir(t *testing.T) {
 
 	if len(stmts) != 0 {
 		t.Fatalf("expected 0 statements, got %d", len(stmts))
+	}
+}
+
+func TestGoquScannerParityFeatureClauses(t *testing.T) {
+	src := `package example
+
+import goqu "github.com/doug-martin/goqu/v9"
+
+func queries(ids []int, minTotal int) {
+	goqu.From("users").
+		Distinct().
+		Where(goqu.C("id").In([]int{1, 2, 3}), goqu.Or(goqu.C("role").Eq("admin"), goqu.C("role").Eq("owner"))).
+		Order(goqu.I("email").Desc(), goqu.I("id").Asc()).
+		Limit(10).
+		Offset(20).
+		Select("id", "email")
+
+	goqu.From("users").Where(goqu.C("id").NotIn([]int{1, 2, 3})).Select("id").Limit(1)
+
+	goqu.From("orders").
+		Select(goqu.SUM(goqu.C("total"))).
+		GroupBy("user_id").
+		Having(goqu.C("total").Gt(minTotal)).
+		Limit(10)
+}
+`
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "parity.go")
+	if err := os.WriteFile(goFile, []byte(src), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	s := &Scanner{}
+	stmts, err := scanner.Collect(s.Scan(context.Background(), []string{tmpDir}))
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+
+	for _, want := range []string{
+		"SELECT DISTINCT id, email FROM users",
+		"id IN ($1, $2, $3)",
+		"(role = 'admin' OR role = 'owner')",
+		"ORDER BY email DESC, id ASC LIMIT 10 OFFSET 20",
+		"id NOT IN ($1, $2, $3)",
+		"SELECT SUM(total) FROM orders",
+		"GROUP BY user_id HAVING total > $1",
+	} {
+		if !scannertest.HasSQLContaining(stmts, want) {
+			t.Fatalf("expected synthetic SQL containing %q, got %+v", want, stmts)
+		}
 	}
 }

--- a/internal/scanner/parity_test.go
+++ b/internal/scanner/parity_test.go
@@ -1,0 +1,212 @@
+// Copyright 2025 ValkDB
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	scannercore "github.com/valkdb/valk-guard/internal/scanner"
+	csharpscanner "github.com/valkdb/valk-guard/internal/scanner/csharp"
+	goquscanner "github.com/valkdb/valk-guard/internal/scanner/goqu"
+	sqlalchemyscanner "github.com/valkdb/valk-guard/internal/scanner/sqlalchemy"
+	"github.com/valkdb/valk-guard/internal/scannertest"
+)
+
+func TestORMScannerParityComplexRuleTriggers(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		ruleID    string
+		goSource  string
+		pySource  string
+		csSource  string
+		fragments []string
+	}{
+		{
+			name:   "select star with join",
+			ruleID: "VG001",
+			goSource: `package parity
+
+import goqu "github.com/doug-martin/goqu/v9"
+
+func run() {
+	goqu.From("Users").Join(goqu.T("Addresses"), goqu.On(goqu.Ex{"Users.Id": goqu.I("Addresses.UserId")})).Select(goqu.Star())
+}
+`,
+			pySource: `def run(session, User, Address):
+    session.query(User).join(Address).all()
+`,
+			csSource: `class Repo {
+    void Run(MyDbContext db) {
+        db.Users.Join(db.Addresses, u => u.Id, a => a.UserId, (u, a) => u).ToList();
+    }
+}
+`,
+			fragments: []string{"SELECT *", "JOIN"},
+		},
+		{
+			name:   "leading wildcard like with join",
+			ruleID: "VG005",
+			goSource: `package parity
+
+import goqu "github.com/doug-martin/goqu/v9"
+
+func run() {
+	goqu.From("Users").Join(goqu.T("Addresses"), goqu.On(goqu.Ex{"Users.Id": goqu.I("Addresses.UserId")})).Where(goqu.C("Email").Like("%@gmail.com")).Select("Users.Id").Limit(10)
+}
+`,
+			pySource: `def run(session, User, Address):
+    session.query(User.id).join(Address).filter(Address.street.like("%Main%")).limit(10).all()
+`,
+			csSource: `class Repo {
+    void Run(MyDbContext db) {
+        db.Users.Join(db.Addresses, u => u.Id, a => a.UserId, (u, a) => u).Where(u => u.Email.Contains("@gmail.com")).Take(10).ToList();
+    }
+}
+`,
+			fragments: []string{"JOIN", "LIKE"},
+		},
+		{
+			name:   "unbounded ordered joined select",
+			ruleID: "VG004",
+			goSource: `package parity
+
+import goqu "github.com/doug-martin/goqu/v9"
+
+func run() {
+	goqu.From("Logs").LeftJoin(goqu.T("Users"), goqu.On(goqu.Ex{"Logs.UserId": goqu.I("Users.Id")})).Select("Logs.Id", "Logs.Message").Order(goqu.I("Logs.Id").Desc())
+}
+`,
+			pySource: `def run(session, Log, User):
+    session.query(Log.id, Log.message).join(User).order_by(Log.id.desc()).all()
+`,
+			csSource: `class Repo {
+    void Run(MyDbContext db) {
+        db.Logs.Join(db.Users, l => l.UserId, u => u.Id, (l, u) => l).OrderByDescending(l => l.Id).Select(l => new { l.Id, l.Message }).ToList();
+    }
+}
+`,
+			fragments: []string{"JOIN", "ORDER BY"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			goSQL := scanGoquParity(t, tc.goSource)
+			pySQL := scanSQLAlchemyParity(t, tc.pySource)
+			csSQL := scanCSharpParity(t, tc.csSource)
+
+			assertRuleFires(t, "goqu", tc.ruleID, goSQL)
+			assertRuleFires(t, "sqlalchemy", tc.ruleID, pySQL)
+			assertRuleFires(t, "csharp", tc.ruleID, csSQL)
+
+			for _, fragment := range tc.fragments {
+				assertAnySQLContains(t, "goqu", goSQL, fragment)
+				assertAnySQLContains(t, "sqlalchemy", pySQL, fragment)
+				assertAnySQLContains(t, "csharp", csSQL, fragment)
+			}
+		})
+	}
+}
+
+func scanGoquParity(t *testing.T, src string) []scannercore.SQLStatement {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "query.go"), src)
+	stmts, err := scannercore.Collect((&goquscanner.Scanner{}).Scan(context.Background(), []string{dir}))
+	if err != nil {
+		t.Fatalf("goqu scan error: %v", err)
+	}
+	return stmts
+}
+
+func scanSQLAlchemyParity(t *testing.T, src string) []scannercore.SQLStatement {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "query.py"), src)
+	stmts, err := scannercore.Collect((&sqlalchemyscanner.Scanner{}).Scan(context.Background(), []string{dir}))
+	if err != nil {
+		t.Fatalf("sqlalchemy scan error: %v", err)
+	}
+	return stmts
+}
+
+func scanCSharpParity(t *testing.T, src string) []scannercore.SQLStatement {
+	t.Helper()
+	requireDotnetForParity(t)
+	dir := t.TempDir()
+	if os.Getenv("VALK_DOTNET_PATH") != "" {
+		var err error
+		dir, err = os.MkdirTemp(".", ".csharp-parity-*")
+		if err != nil {
+			t.Fatalf("create local C# temp dir: %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	}
+	writeFile(t, filepath.Join(dir, "Query.cs"), src)
+	project := filepath.Join("csharp", "roslynextractor", "RoslynExtractor.csproj")
+	s := &csharpscanner.Scanner{DotnetPath: os.Getenv("VALK_DOTNET_PATH"), ProjectPath: project}
+	stmts, err := scannercore.Collect(s.Scan(context.Background(), []string{dir}))
+	if err != nil {
+		t.Fatalf("csharp scan error: %v", err)
+	}
+	return stmts
+}
+
+func requireDotnetForParity(t *testing.T) {
+	t.Helper()
+	if path := os.Getenv("VALK_DOTNET_PATH"); path != "" {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("VALK_DOTNET_PATH is set but not usable: %v", err)
+		}
+		return
+	}
+	if _, err := exec.LookPath("dotnet"); err != nil {
+		if os.Getenv("VALK_REQUIRE_DOTNET") == "1" {
+			t.Fatalf("dotnet SDK is required for C# parity tests: %v", err)
+		}
+		t.Skip("dotnet SDK is required for C# parity tests")
+	}
+}
+
+func writeFile(t *testing.T, path, src string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func assertRuleFires(t *testing.T, engine, ruleID string, stmts []scannercore.SQLStatement) {
+	t.Helper()
+	findings := scannertest.CollectFindingsByRule(t, stmts)
+	if findings[ruleID] == 0 {
+		t.Fatalf("expected %s to fire %s, got findings=%+v sql=%s", engine, ruleID, findings, joinSQL(stmts))
+	}
+}
+
+func assertAnySQLContains(t *testing.T, engine string, stmts []scannercore.SQLStatement, fragment string) {
+	t.Helper()
+	needle := strings.ToUpper(fragment)
+	for _, stmt := range stmts {
+		if strings.Contains(strings.ToUpper(stmt.SQL), needle) {
+			return
+		}
+	}
+	t.Fatalf("expected %s SQL to contain %q, got %s", engine, fragment, joinSQL(stmts))
+}
+
+func joinSQL(stmts []scannercore.SQLStatement) string {
+	parts := make([]string, 0, len(stmts))
+	for _, stmt := range stmts {
+		parts = append(parts, stmt.SQL)
+	}
+	return strings.Join(parts, " | ")
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -26,6 +26,8 @@ const (
 	EngineGoqu Engine = "goqu"
 	// EngineSQLAlchemy represents SQL extracted/synthesized from SQLAlchemy usage.
 	EngineSQLAlchemy Engine = "sqlalchemy"
+	// EngineCSharp represents SQL extracted from EF Core raw SQL execution in C# files.
+	EngineCSharp Engine = "csharp"
 )
 
 // SQLStatement represents a SQL statement extracted from a source file.
@@ -36,7 +38,7 @@ type SQLStatement struct {
 	Column    int      // 1-based column where the statement starts.
 	EndLine   int      // 1-based line number where the statement ends.
 	EndColumn int      // 1-based column where the statement ends.
-	Engine    Engine   // Statement source engine (sql/go/goqu/sqlalchemy).
+	Engine    Engine   // Statement source engine (sql/go/goqu/sqlalchemy/csharp).
 	Disabled  []string // Rule IDs disabled via inline directives.
 }
 

--- a/internal/scanner/sql_heuristic.go
+++ b/internal/scanner/sql_heuristic.go
@@ -1,0 +1,69 @@
+// Copyright 2025 ValkDB
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import "strings"
+
+// sqlKeywordSet maps known SQL statement-opening keywords to an empty struct
+// for O(1) lookup. The LooksLikeSQL function extracts the first word from the
+// input and checks for membership here instead of iterating a slice.
+var sqlKeywordSet = map[string]struct{}{
+	"SELECT":   {},
+	"INSERT":   {},
+	"UPDATE":   {},
+	"DELETE":   {},
+	"CREATE":   {},
+	"DROP":     {},
+	"ALTER":    {},
+	"TRUNCATE": {},
+	"WITH":     {},
+	"GRANT":    {},
+	"REVOKE":   {},
+	"BEGIN":    {},
+	"COMMIT":   {},
+	"ROLLBACK": {},
+	"SET":      {},
+	"COPY":     {},
+	"VACUUM":   {},
+	"ANALYZE":  {},
+	"EXPLAIN":  {},
+	"MERGE":    {},
+}
+
+// LooksLikeSQL reports whether the string appears to be a SQL statement
+// by checking for common starting keywords or comments.
+// It extracts only the first word (letters A-Z) and performs an O(1) map
+// lookup instead of a linear scan over all keywords.
+func LooksLikeSQL(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	// Allow SQL line/block comments as valid statement starts.
+	if strings.HasPrefix(s, "--") || strings.HasPrefix(s, "/*") {
+		return true
+	}
+	upper := strings.ToUpper(s)
+	// Extract the leading alphabetic word (SQL keywords are all letters).
+	end := 0
+	for end < len(upper) && upper[end] >= 'A' && upper[end] <= 'Z' {
+		end++
+	}
+	if end == 0 {
+		return false
+	}
+	// Ensure the keyword is not a prefix of a longer identifier (e.g. "SELECTOR").
+	if end < len(upper) && isSQLIdentChar(upper[end]) {
+		return false
+	}
+	_, ok := sqlKeywordSet[upper[:end]]
+	return ok
+}
+
+func isSQLIdentChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '_'
+}

--- a/internal/scanner/sqlalchemy/extract_sql.py
+++ b/internal/scanner/sqlalchemy/extract_sql.py
@@ -11,12 +11,10 @@ end_column, sql
 
 import ast
 import json
-import re
 import sys
 
 
 SYNTHETIC_PREFIX = "/* valk-guard:synthetic sqlalchemy-ast */ "
-IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*$")
 JOIN_METHODS = {"join", "outerjoin", "leftouterjoin"}
 FILTER_METHODS = {"filter", "filter_by", "where"}
 FOR_UPDATE_METHODS = {"with_for_update"}
@@ -151,6 +149,7 @@ def _synthesize_query_chain(chain, tablename_map):
     joins = []
     join_tables = []
     predicates = []
+    placeholders = _PlaceholderAllocator()
     has_filter = False
     has_limit = False
     has_for_update = False
@@ -166,7 +165,7 @@ def _synthesize_query_chain(chain, tablename_map):
 
         if method in FILTER_METHODS:
             has_filter = True
-            conds = _predicates_from_filter_call(method, link["args"], link["keywords"], tablename_map)
+            conds = _predicates_from_filter_call(method, link["args"], link["keywords"], tablename_map, placeholders)
             if not conds:
                 conds = ["1=1"]
             predicates.extend(conds)
@@ -204,6 +203,7 @@ def _synthesize_select_chain(chain, tablename_map):
 
     joins = []
     predicates = []
+    placeholders = _PlaceholderAllocator()
     has_filter = False
     has_limit = False
     has_for_update = False
@@ -218,7 +218,7 @@ def _synthesize_select_chain(chain, tablename_map):
 
         if method in FILTER_METHODS:
             has_filter = True
-            conds = _predicates_from_filter_call(method, link["args"], link["keywords"], tablename_map)
+            conds = _predicates_from_filter_call(method, link["args"], link["keywords"], tablename_map, placeholders)
             if not conds:
                 conds = ["1=1"]
             predicates.extend(conds)
@@ -325,7 +325,7 @@ def _join_clause(method, table):
     return f"{join_type} {table} ON 1=1"
 
 
-def _predicates_from_filter_call(method, args, keywords, tablename_map):
+def _predicates_from_filter_call(method, args, keywords, tablename_map, placeholders):
     predicates = []
 
     if method == "filter_by":
@@ -333,17 +333,17 @@ def _predicates_from_filter_call(method, args, keywords, tablename_map):
             if not kw.arg:
                 continue
             col = _safe_ident(kw.arg, "synthetic_col")
-            predicates.append(f"{col} = {_sql_value(kw.value)}")
+            predicates.append(f"{col} = {_sql_value(kw.value, placeholders)}")
 
     for arg in args:
-        pred = _predicate_from_expr(arg, tablename_map)
+        pred = _predicate_from_expr(arg, tablename_map, placeholders)
         if pred:
             predicates.append(pred)
 
     return predicates
 
 
-def _predicate_from_expr(node, tablename_map):
+def _predicate_from_expr(node, tablename_map, placeholders):
     if isinstance(node, ast.Call):
         if isinstance(node.func, ast.Name) and node.func.id == "text":
             sql = _get_first_string_arg(node)
@@ -355,19 +355,19 @@ def _predicate_from_expr(node, tablename_map):
             col = _column_name_from_expr(node.func.value, "synthetic_col", tablename_map)
 
             if method == "like":
-                return f"{col} LIKE {_sql_value(_first_arg(node.args))}"
+                return f"{col} LIKE {_sql_value(_first_arg(node.args), placeholders)}"
             if method == "ilike":
-                return f"{col} ILIKE {_sql_value(_first_arg(node.args))}"
+                return f"{col} ILIKE {_sql_value(_first_arg(node.args), placeholders)}"
             if method == "contains":
-                return f"{col} LIKE {_wrapped_like_value(_first_arg(node.args), '%', '%')}"
+                return f"{col} LIKE {_wrapped_like_value(_first_arg(node.args), '%', '%', placeholders)}"
             if method == "startswith":
-                return f"{col} LIKE {_wrapped_like_value(_first_arg(node.args), '', '%')}"
+                return f"{col} LIKE {_wrapped_like_value(_first_arg(node.args), '', '%', placeholders)}"
             if method == "endswith":
-                return f"{col} LIKE {_wrapped_like_value(_first_arg(node.args), '%', '')}"
+                return f"{col} LIKE {_wrapped_like_value(_first_arg(node.args), '%', '', placeholders)}"
 
     if isinstance(node, ast.Compare):
         left = _column_name_from_expr(node.left, "synthetic_col", tablename_map)
-        right = _sql_value(_first_arg(node.comparators))
+        right = _sql_value(_first_arg(node.comparators), placeholders)
         if not node.ops:
             return None
         op = _compare_op(node.ops[0])
@@ -375,7 +375,7 @@ def _predicate_from_expr(node, tablename_map):
             return f"{left} {op} {right}"
 
     if isinstance(node, ast.BoolOp):
-        pieces = [_predicate_from_expr(v, tablename_map) for v in node.values]
+        pieces = [_predicate_from_expr(v, tablename_map, placeholders) for v in node.values]
         pieces = [p for p in pieces if p]
         if not pieces:
             return None
@@ -405,10 +405,10 @@ def _compare_op(op):
     return None
 
 
-def _wrapped_like_value(node, prefix, suffix):
+def _wrapped_like_value(node, prefix, suffix, placeholders):
     s = _string_literal(node)
     if s is None:
-        return "'%synthetic%'"
+        return placeholders.next()
     s = s.replace("'", "''")
     return "'" + prefix + s + suffix + "'"
 
@@ -493,7 +493,7 @@ def _limit_from_args(args):
     return "1"
 
 
-def _sql_value(node):
+def _sql_value(node, placeholders):
     if node is None:
         return "NULL"
 
@@ -511,7 +511,20 @@ def _sql_value(node):
         if isinstance(node.operand, ast.Constant) and isinstance(node.operand.value, (int, float)):
             return "-" + str(node.operand.value)
 
-    return "'synthetic_value'"
+    return placeholders.next()
+
+
+class _PlaceholderAllocator:
+    """Allocate PostgreSQL-style bind placeholders for one synthetic SQL statement."""
+
+    def __init__(self):
+        self._next = 1
+
+    def next(self):
+        """Return the next numbered bind placeholder."""
+        value = f"${self._next}"
+        self._next += 1
+        return value
 
 
 def _string_literal(node):
@@ -645,9 +658,24 @@ def _safe_ident(raw, fallback):
     raw = raw.split()[0].rstrip(",")
     if raw == "*":
         return raw
-    if IDENT_RE.match(raw):
+    if _is_dotted_identifier(raw):
         return _quote_ident(raw)
     return _quote_ident(fallback)
+
+
+def _is_identifier_part(text):
+    """Return whether text is a SQL identifier segment without regex."""
+    if not text:
+        return False
+    first = text[0]
+    if not (first == "_" or first.isalpha()):
+        return False
+    return all(ch == "_" or ch.isalnum() for ch in text[1:])
+
+
+def _is_dotted_identifier(text):
+    """Return whether text is a dotted SQL identifier without regex."""
+    return all(_is_identifier_part(part) for part in text.split("."))
 
 
 def _quote_ident(name):

--- a/internal/scanner/sqlalchemy/extract_sql.py
+++ b/internal/scanner/sqlalchemy/extract_sql.py
@@ -17,7 +17,11 @@ import sys
 SYNTHETIC_PREFIX = "/* valk-guard:synthetic sqlalchemy-ast */ "
 JOIN_METHODS = {"join", "outerjoin", "leftouterjoin"}
 FILTER_METHODS = {"filter", "filter_by", "where"}
+ORDER_METHODS = {"order_by"}
+GROUP_METHODS = {"group_by"}
+HAVING_METHODS = {"having"}
 FOR_UPDATE_METHODS = {"with_for_update"}
+AGGREGATE_FUNCS = {"sum": "SUM", "min": "MIN", "max": "MAX", "avg": "AVG", "average": "AVG", "count": "COUNT"}
 
 
 def _build_tablename_map(tree):
@@ -149,18 +153,41 @@ def _synthesize_query_chain(chain, tablename_map):
     joins = []
     join_tables = []
     predicates = []
+    group_by = []
+    having = []
+    order_by = []
     placeholders = _PlaceholderAllocator()
+    distinct = False
     has_filter = False
     has_limit = False
+    has_offset = False
     has_for_update = False
     limit_val = "1"
+    offset_val = "1"
 
     for link in chain[1:end]:
         method = link["name"].lower()
         if method in JOIN_METHODS:
             table = _table_name_from_expr(_first_arg(link["args"]), "synthetic_join", tablename_map)
-            joins.append(_join_clause(method, table))
+            joins.append(_join_clause(method, table, link, tablename_map, placeholders))
             join_tables.append(table)
+            continue
+
+        if method == "distinct":
+            distinct = True
+            continue
+
+        if method in ORDER_METHODS:
+            order_by.extend(_order_by_from_args(link["args"], tablename_map))
+            continue
+
+        if method in GROUP_METHODS:
+            group_by.extend(_columns_from_args(link["args"], tablename_map))
+            continue
+
+        if method in HAVING_METHODS:
+            conds = _predicates_from_filter_call(method, link["args"], link["keywords"], tablename_map, placeholders)
+            having.extend(conds or ["1=1"])
             continue
 
         if method in FILTER_METHODS:
@@ -174,6 +201,11 @@ def _synthesize_query_chain(chain, tablename_map):
         if method == "limit":
             has_limit = True
             limit_val = _limit_from_args(link["args"])
+            continue
+
+        if method == "offset":
+            has_offset = True
+            offset_val = _limit_from_args(link["args"])
             continue
 
         if method in FOR_UPDATE_METHODS:
@@ -193,6 +225,12 @@ def _synthesize_query_chain(chain, tablename_map):
         has_limit,
         limit_val,
         has_for_update,
+        distinct,
+        group_by,
+        having,
+        order_by,
+        has_offset,
+        offset_val,
     )
 
 
@@ -203,17 +241,40 @@ def _synthesize_select_chain(chain, tablename_map):
 
     joins = []
     predicates = []
+    group_by = []
+    having = []
+    order_by = []
     placeholders = _PlaceholderAllocator()
+    distinct = False
     has_filter = False
     has_limit = False
+    has_offset = False
     has_for_update = False
     limit_val = "1"
+    offset_val = "1"
 
     for link in chain[1:]:
         method = link["name"].lower()
         if method in JOIN_METHODS:
             table = _table_name_from_expr(_first_arg(link["args"]), "synthetic_join", tablename_map)
-            joins.append(_join_clause(method, table))
+            joins.append(_join_clause(method, table, link, tablename_map, placeholders))
+            continue
+
+        if method == "distinct":
+            distinct = True
+            continue
+
+        if method in ORDER_METHODS:
+            order_by.extend(_order_by_from_args(link["args"], tablename_map))
+            continue
+
+        if method in GROUP_METHODS:
+            group_by.extend(_columns_from_args(link["args"], tablename_map))
+            continue
+
+        if method in HAVING_METHODS:
+            conds = _predicates_from_filter_call(method, link["args"], link["keywords"], tablename_map, placeholders)
+            having.extend(conds or ["1=1"])
             continue
 
         if method in FILTER_METHODS:
@@ -229,6 +290,11 @@ def _synthesize_select_chain(chain, tablename_map):
             limit_val = _limit_from_args(link["args"])
             continue
 
+        if method == "offset":
+            has_offset = True
+            offset_val = _limit_from_args(link["args"])
+            continue
+
         if method in FOR_UPDATE_METHODS:
             has_for_update = True
 
@@ -241,6 +307,12 @@ def _synthesize_select_chain(chain, tablename_map):
         has_limit,
         limit_val,
         has_for_update,
+        distinct,
+        group_by,
+        having,
+        order_by,
+        has_offset,
+        offset_val,
     )
 
 
@@ -287,14 +359,38 @@ def _operation_from_chain(chain):
     return None, None
 
 
-def _build_select_sql(columns, table, joins, has_filter, predicates, has_limit, limit_val, has_for_update):
-    sql = f"SELECT {', '.join(columns)} FROM {table}"
+def _build_select_sql(
+    columns,
+    table,
+    joins,
+    has_filter,
+    predicates,
+    has_limit,
+    limit_val,
+    has_for_update,
+    distinct,
+    group_by,
+    having,
+    order_by,
+    has_offset,
+    offset_val,
+):
+    modifier = "DISTINCT " if distinct else ""
+    sql = f"SELECT {modifier}{', '.join(columns)} FROM {table}"
     if joins:
         sql += " " + " ".join(joins)
     if has_filter and predicates:
         sql += " WHERE " + " AND ".join(predicates)
+    if group_by:
+        sql += " GROUP BY " + ", ".join(group_by)
+    if having:
+        sql += " HAVING " + " AND ".join(having)
+    if order_by:
+        sql += " ORDER BY " + ", ".join(order_by)
     if has_limit:
         sql += " LIMIT " + limit_val
+    if has_offset:
+        sql += " OFFSET " + offset_val
     if has_for_update:
         sql += " FOR UPDATE"
     return sql
@@ -318,11 +414,47 @@ def _build_delete_sql(table, join_tables, has_filter, predicates):
     return sql
 
 
-def _join_clause(method, table):
+def _join_clause(method, table, link, tablename_map, placeholders):
     join_type = "JOIN"
-    if method in {"outerjoin", "leftouterjoin"}:
+    keywords = {kw.arg: kw.value for kw in link.get("keywords", []) if kw.arg}
+    if method in {"outerjoin", "leftouterjoin"} or _truthy_keyword(keywords.get("isouter")):
         join_type = "LEFT JOIN"
-    return f"{join_type} {table} ON 1=1"
+    if _truthy_keyword(keywords.get("full")):
+        join_type = "FULL JOIN"
+    on = "1=1"
+    if len(link["args"]) > 1:
+        on = _predicate_from_expr(link["args"][1], tablename_map, placeholders) or "1=1"
+    return f"{join_type} {table} ON {on}"
+
+
+def _columns_from_args(args, tablename_map):
+    """Resolve a list of SQLAlchemy expressions into column identifiers."""
+    columns = []
+    for arg in args:
+        col = _column_name_from_expr(arg, "", tablename_map)
+        if col:
+            columns.append(col)
+    return columns
+
+
+def _order_by_from_args(args, tablename_map):
+    """Resolve SQLAlchemy order_by arguments into ORDER BY fragments."""
+    orders = []
+    for arg in args:
+        direction = "ASC"
+        expr = arg
+        if isinstance(arg, ast.Call) and isinstance(arg.func, ast.Attribute) and arg.func.attr.lower() in {"desc", "asc"}:
+            direction = "DESC" if arg.func.attr.lower() == "desc" else "ASC"
+            expr = arg.func.value if not arg.args else arg.args[0]
+        col = _column_name_from_expr(expr, "", tablename_map)
+        if col:
+            orders.append(f"{col} {direction}")
+    return orders
+
+
+def _truthy_keyword(node):
+    """Return whether a keyword expression is statically true."""
+    return isinstance(node, ast.Constant) and node.value is True
 
 
 def _predicates_from_filter_call(method, args, keywords, tablename_map, placeholders):
@@ -358,19 +490,31 @@ def _predicate_from_expr(node, tablename_map, placeholders):
                 return f"{col} LIKE {_sql_value(_first_arg(node.args), placeholders)}"
             if method == "ilike":
                 return f"{col} ILIKE {_sql_value(_first_arg(node.args), placeholders)}"
+            if method in {"in_", "notin_", "not_in"}:
+                op = "NOT IN" if method in {"notin_", "not_in"} else "IN"
+                return f"{col} {op} ({_bind_list_from_expr(_first_arg(node.args), placeholders)})"
             if method == "contains":
                 return f"{col} LIKE {_wrapped_like_value(_first_arg(node.args), '%', '%', placeholders)}"
             if method == "startswith":
                 return f"{col} LIKE {_wrapped_like_value(_first_arg(node.args), '', '%', placeholders)}"
             if method == "endswith":
                 return f"{col} LIKE {_wrapped_like_value(_first_arg(node.args), '%', '', placeholders)}"
+            if method in {"is_", "isnot"}:
+                op = "IS NOT" if method == "isnot" else "IS"
+                return f"{col} {op} {_sql_value(_first_arg(node.args), placeholders)}"
 
     if isinstance(node, ast.Compare):
         left = _column_name_from_expr(node.left, "synthetic_col", tablename_map)
-        right = _sql_value(_first_arg(node.comparators), placeholders)
         if not node.ops:
             return None
         op = _compare_op(node.ops[0])
+        comparator = _first_arg(node.comparators)
+        if op in {"IN", "NOT IN"}:
+            right = "(" + _bind_list_from_expr(comparator, placeholders) + ")"
+        elif isinstance(comparator, ast.Attribute):
+            right = _column_name_from_expr(comparator, "synthetic_col", tablename_map)
+        else:
+            right = _sql_value(comparator, placeholders)
         if op:
             return f"{left} {op} {right}"
 
@@ -455,8 +599,15 @@ def _column_name_from_expr(node, fallback, tablename_map=None):
         return _safe_ident(node.value, fallback)
 
     if isinstance(node, ast.Call):
-        # Handle wrappers such as func.lower(User.email)
         if isinstance(node.func, ast.Attribute):
+            func_name = node.func.attr.lower()
+            if func_name in AGGREGATE_FUNCS:
+                arg = _first_arg(node.args)
+                col = "*" if arg is None else _column_name_from_expr(arg, "synthetic_col", tablename_map)
+                return f"{AGGREGATE_FUNCS[func_name]}({col})"
+            if func_name in {"desc", "asc"}:
+                expr = node.func.value if not node.args else node.args[0]
+                return _column_name_from_expr(expr, fallback, tablename_map)
             return _column_name_from_expr(node.func.value, fallback, tablename_map)
         if node.args:
             return _column_name_from_expr(node.args[0], fallback, tablename_map)
@@ -525,6 +676,14 @@ class _PlaceholderAllocator:
         value = f"${self._next}"
         self._next += 1
         return value
+
+
+def _bind_list_from_expr(node, placeholders):
+    """Render bind placeholders for IN/NOT IN with static arity when available."""
+    arity = 3
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)) and node.elts:
+        arity = len(node.elts)
+    return ", ".join(placeholders.next() for _ in range(arity))
 
 
 def _string_literal(node):

--- a/internal/scanner/sqlalchemy/sqlalchemy_scanner_test.go
+++ b/internal/scanner/sqlalchemy/sqlalchemy_scanner_test.go
@@ -176,7 +176,7 @@ session.query(User).join(Order, Order.user_id == User.id).filter(User.active == 
 	if !scannertest.HasSQLContaining(stmts, `FROM "users"`) {
 		t.Errorf("expected resolved table name 'users' in FROM clause, got %+v", stmts)
 	}
-	if !scannertest.HasSQLContaining(stmts, `JOIN "orders" ON 1=1`) {
+	if !scannertest.HasSQLContaining(stmts, `JOIN "orders" ON "orders"."user_id" = "users"."id"`) {
 		t.Errorf("expected resolved table name 'orders' in JOIN clause, got %+v", stmts)
 	}
 }
@@ -292,7 +292,7 @@ def run(session: Session):
 	if len(stmts) == 0 {
 		t.Fatal("expected synthetic SQL from imported SQLAlchemy models, got 0 statements")
 	}
-	if !scannertest.HasSQLContaining(stmts, `FROM "users" LEFT JOIN "orders" ON 1=1`) {
+	if !scannertest.HasSQLContaining(stmts, `FROM "users" LEFT JOIN "orders" ON "orders"."user_id" = "users"."id"`) {
 		t.Fatalf("expected imported __tablename__ values in JOIN SQL, got %+v", stmts)
 	}
 	if !scannertest.HasSQLContaining(stmts, `"orders"."status"`) {
@@ -318,5 +318,39 @@ def run(session)
 	}
 	if !strings.Contains(err.Error(), "python script execution failed") {
 		t.Fatalf("expected extractor failure error, got %v", err)
+	}
+}
+
+func TestSQLAlchemyScannerParityFeatureClauses(t *testing.T) {
+	tmpDir := t.TempDir()
+	pyFile := filepath.Join(tmpDir, "parity.py")
+
+	content := `from sqlalchemy import func
+
+def run(session, User, Address, min_count):
+    session.query(User.id, func.count(Address.id)).distinct().join(Address, Address.user_id == User.id).filter(User.id.in_([1, 2, 3])).group_by(User.id).having(func.count(Address.id) > min_count).order_by(User.email.desc(), User.id).limit(10).offset(20).all()
+    session.query(User.id).filter(User.id.notin_([1, 2, 3])).limit(1).all()
+`
+	if err := os.WriteFile(pyFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	s := &Scanner{}
+	stmts, err := scanner.Collect(s.Scan(context.Background(), []string{tmpDir}))
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+
+	for _, want := range []string{
+		`SELECT DISTINCT "User"."id", COUNT("Address"."id") FROM "User"`,
+		`JOIN "Address" ON "Address"."user_id" = "User"."id"`,
+		`"User"."id" IN ($1, $2, $3)`,
+		`GROUP BY "User"."id" HAVING COUNT("Address"."id") > $4`,
+		`ORDER BY "User"."email" DESC, "User"."id" ASC LIMIT 10 OFFSET 20`,
+		`"User"."id" NOT IN ($1, $2, $3)`,
+	} {
+		if !scannertest.HasSQLContaining(stmts, want) {
+			t.Fatalf("expected synthetic SQL containing %q, got %+v", want, stmts)
+		}
 	}
 }

--- a/testdata/success_criteria.md
+++ b/testdata/success_criteria.md
@@ -1,0 +1,93 @@
+# Success Criteria: ORM Synthetic SQL
+
+Every case below exercises a join or complex structure so scanners prove they
+feed realistic SQL into the existing parser and rule engine.
+
+## Group A: Raw SQL Baseline Complex Queries
+
+1. VG001 select-star with joins:
+
+```sql
+SELECT * FROM users u LEFT JOIN orders o ON u.id = o.uid JOIN logs l ON u.id = l.uid;
+```
+
+2. VG005 invalid LIKE with joins:
+
+```sql
+SELECT u.id FROM users u JOIN comments c ON u.id = c.uid WHERE c.body LIKE '%error%';
+```
+
+3. VG002 update with join and missing WHERE:
+
+```sql
+UPDATE inventory i FROM shipments s SET i.stock = 0;
+```
+
+## Group B: Goqu Go AST to Synthetic SQL
+
+4. VG001 select-star with join:
+
+```go
+goqu.From("users").Join(goqu.T("orders"), goqu.On(goqu.Ex{"users.id": goqu.I("orders.uid")})).Select(goqu.Star())
+// Synthetic: SELECT * FROM users JOIN orders ON 1=1
+```
+
+5. VG005 leading wildcard LIKE:
+
+```go
+goqu.From("users").Join(goqu.T("profiles"), goqu.On(goqu.Ex{"users.id": goqu.I("profiles.uid")})).Where(goqu.C("email").Like("%@gmail.com")).Select("users.id")
+// Synthetic: SELECT users.id FROM users JOIN profiles ON 1=1 WHERE email LIKE '%@gmail.com'
+```
+
+6. VG004 unbounded select with joins:
+
+```go
+goqu.From("logs").LeftJoin(goqu.T("users"), goqu.On(goqu.Ex{"logs.uid": goqu.I("users.id")})).Select("logs.id", "logs.msg")
+// Synthetic: SELECT logs.id, logs.msg FROM logs LEFT JOIN users ON 1=1
+```
+
+## Group C: SQLAlchemy Python AST to Synthetic SQL
+
+7. VG001 ORM select-star with join:
+
+```python
+session.query(User).join(Address).all()
+# Synthetic: SELECT * FROM User JOIN Address ON 1=1
+```
+
+8. VG005 invalid LIKE pattern:
+
+```python
+session.query(User).join(Address).filter(Address.street.like("%Main%")).all()
+# Synthetic: SELECT * FROM User JOIN Address ON 1=1 WHERE street LIKE '%Main%'
+```
+
+9. VG003 delete with join and missing filter:
+
+```python
+session.query(User).join(Roles).delete()
+# Synthetic: DELETE FROM User
+```
+
+## Group D: C# EF Core Roslyn AST to Synthetic SQL
+
+10. VG001 select-star with include join:
+
+```csharp
+db.Users.Include(u => u.Orders).ToList();
+// Synthetic: SELECT * FROM Users LEFT JOIN Orders ON 1=1
+```
+
+11. VG005 invalid LIKE pattern:
+
+```csharp
+db.Users.Include(u => u.Profile).Where(u => u.Email.Contains("@gmail.com")).ToList();
+// Synthetic: SELECT * FROM Users LEFT JOIN Profile ON 1=1 WHERE Email LIKE '%@gmail.com%'
+```
+
+12. VG003 delete with join-like include and missing filter:
+
+```csharp
+db.Users.Include(u => u.Roles).ExecuteDelete();
+// Synthetic: DELETE FROM Users
+```


### PR DESCRIPTION
## Summary
Add a new `csharp` scanner engine for EF Core raw SQL execution in `.cs` files.

## Motivation
Issue #16 asks for `.cs` file support. This PR intentionally keeps scope narrow to raw EF Core SQL execution only, matching the existing raw-SQL extraction model used for other source languages. Broader C# ORM/query-builder support remains tracked in #17.

## Changes
- add a `csharp` scanner for `ExecuteSqlRaw`, `ExecuteSqlRawAsync`, `ExecuteSqlInterpolated`, and `ExecuteSqlInterpolatedAsync`
- validate supported receivers and keep variable resolution limited to the enclosing method scope
- wire `.cs` files into engine/source binding selection
- add C# scanner tests for literals, interpolation, local variables, helper methods, async variants, and conservative skips
- update README, docs, and config examples to describe C# raw-query support accurately

## Testing
- [ ] `make check` passes
- [x] New/updated tests cover the changes
- [x] Tested manually with relevant SQL/Go/Python files

## Checklist
- [x] Code follows existing project conventions
- [x] Doc comments added for new exported types/functions
- [x] README updated if user-facing behavior changed
