### PR TITLE
fix(csharp): tolerate stray dotnet stdout noise before extractor JSON

### DIFF
--- a/internal/scanner/csharp/roslynextractor/Program.cs
+++ b/internal/scanner/csharp/roslynextractor/Program.cs
@@ -30,12 +30,24 @@ internal static class Program
     };
 
     /// <summary>
-    /// Parses all input files and prints JSON extraction results to stdout.
+    /// Parses all input files and writes JSON extraction results.
+    /// When the first argument is <c>--output=PATH</c>, results are written to
+    /// that file; otherwise they are written to stdout. The file form is used
+    /// by the Go scanner so that build/restore noise from <c>dotnet run</c>
+    /// cannot corrupt the JSON payload.
     /// </summary>
     public static int Main(string[] args)
     {
+        string? outputPath = null;
+        IEnumerable<string> inputs = args;
+        if (args.Length > 0 && args[0].StartsWith("--output=", StringComparison.Ordinal))
+        {
+            outputPath = args[0].Substring("--output=".Length);
+            inputs = args.Skip(1);
+        }
+
         var results = new List<SqlResult>();
-        foreach (var file in args)
+        foreach (var file in inputs)
         {
             try
             {
@@ -48,7 +60,15 @@ internal static class Program
             }
         }
 
-        Console.Write(JsonSerializer.Serialize(results));
+        var json = JsonSerializer.Serialize(results);
+        if (outputPath is not null)
+        {
+            File.WriteAllText(outputPath, json);
+        }
+        else
+        {
+            Console.Write(json);
+        }
         return 0;
     }
 

--- a/internal/scanner/csharp/scanner.go
+++ b/internal/scanner/csharp/scanner.go
@@ -216,8 +216,8 @@ func (s *Scanner) runRoslynExtractor(parent context.Context, files []string) ([]
 
 // runRoslynProject executes an explicit extractor project with dotnet run.
 func runRoslynProject(ctx context.Context, dotnet, projectPath string, files []string, timeout time.Duration) ([]csResult, error) {
-	args := make([]string, 0, 4+len(files))
-	args = append(args, "run", "--project", projectPath, "--")
+	args := make([]string, 0, 6+len(files))
+	args = append(args, "run", "--project", projectPath, "--verbosity", "quiet", "--")
 	args = append(args, files...)
 	//nolint:gosec // dotnet is a resolved SDK executable and args point at scanner-selected source files.
 	//nolint:gosec // dotnet is a resolved SDK executable used to publish scanner-owned embedded code.
@@ -248,11 +248,23 @@ func decodeRoslynCommand(cmd *exec.Cmd, ctx context.Context, timeout time.Durati
 		return nil, fmt.Errorf("csharp Roslyn extractor failed: %w: %s", err, strings.TrimSpace(stderr.String()))
 	}
 
+	payload := trimToJSONArray(stdout.Bytes())
 	var results []csResult
-	if err := json.Unmarshal(stdout.Bytes(), &results); err != nil {
+	if err := json.Unmarshal(payload, &results); err != nil {
 		return nil, fmt.Errorf("decode C# Roslyn extractor output: %w", err)
 	}
 	return results, nil
+}
+
+// trimToJSONArray returns the slice starting at the first '[' byte, or the
+// original input when no opening bracket is found. Defends against stray
+// build/restore lines that some dotnet SDKs print to stdout ahead of the
+// extractor's JSON payload, which would otherwise break json.Unmarshal.
+func trimToJSONArray(b []byte) []byte {
+	if i := bytes.IndexByte(b, '['); i > 0 {
+		return b[i:]
+	}
+	return b
 }
 
 // ensureCachedRoslynExtractorPublished publishes a self-contained extractor

--- a/internal/scanner/csharp/scanner.go
+++ b/internal/scanner/csharp/scanner.go
@@ -216,26 +216,43 @@ func (s *Scanner) runRoslynExtractor(parent context.Context, files []string) ([]
 
 // runRoslynProject executes an explicit extractor project with dotnet run.
 func runRoslynProject(ctx context.Context, dotnet, projectPath string, files []string, timeout time.Duration) ([]csResult, error) {
-	args := make([]string, 0, 6+len(files))
-	args = append(args, "run", "--project", projectPath, "--verbosity", "quiet", "--")
+	outputPath, cleanup, err := newExtractorOutputFile(files)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	args := make([]string, 0, 7+len(files))
+	args = append(args, "run", "--project", projectPath, "--verbosity", "quiet", "--", "--output="+pathForDotnet(dotnet, outputPath))
 	args = append(args, files...)
 	//nolint:gosec // dotnet is a resolved SDK executable and args point at scanner-selected source files.
 	//nolint:gosec // dotnet is a resolved SDK executable used to publish scanner-owned embedded code.
 	//nolint:gosec // dotnet is a resolved SDK executable used to publish scanner-owned embedded code.
 	cmd := exec.CommandContext(ctx, dotnet, args...)
 	cmd.Env = dotnetEnv()
-	return decodeRoslynCommand(cmd, ctx, timeout)
+	return runRoslynCommand(cmd, ctx, timeout, outputPath)
 }
 
 // runRoslynBinary executes the cached published extractor binary.
 func runRoslynBinary(ctx context.Context, executablePath string, files []string, timeout time.Duration) ([]csResult, error) {
+	outputPath, cleanup, err := newExtractorOutputFile(files)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	binArgs := make([]string, 0, 1+len(files))
+	binArgs = append(binArgs, "--output="+outputPath)
+	binArgs = append(binArgs, files...)
 	//nolint:gosec // executablePath is the scanner-owned cached extractor binary.
-	cmd := exec.CommandContext(ctx, executablePath, files...)
-	return decodeRoslynCommand(cmd, ctx, timeout)
+	cmd := exec.CommandContext(ctx, executablePath, binArgs...)
+	return runRoslynCommand(cmd, ctx, timeout, outputPath)
 }
 
-// decodeRoslynCommand runs cmd and decodes the extractor JSON result stream.
-func decodeRoslynCommand(cmd *exec.Cmd, ctx context.Context, timeout time.Duration) ([]csResult, error) {
+// runRoslynCommand runs cmd and decodes the extractor JSON result file. The
+// extractor writes its JSON payload to outputPath so that any stray
+// build/restore lines on stdout cannot corrupt the result.
+func runRoslynCommand(cmd *exec.Cmd, ctx context.Context, timeout time.Duration, outputPath string) ([]csResult, error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -248,7 +265,11 @@ func decodeRoslynCommand(cmd *exec.Cmd, ctx context.Context, timeout time.Durati
 		return nil, fmt.Errorf("csharp Roslyn extractor failed: %w: %s", err, strings.TrimSpace(stderr.String()))
 	}
 
-	payload := trimToJSONArray(stdout.Bytes())
+	//nolint:gosec // outputPath is created by newExtractorOutputFile in a private temp dir.
+	payload, err := os.ReadFile(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("read C# Roslyn extractor output: %w", err)
+	}
 	var results []csResult
 	if err := json.Unmarshal(payload, &results); err != nil {
 		return nil, fmt.Errorf("decode C# Roslyn extractor output: %w", err)
@@ -256,15 +277,23 @@ func decodeRoslynCommand(cmd *exec.Cmd, ctx context.Context, timeout time.Durati
 	return results, nil
 }
 
-// trimToJSONArray returns the slice starting at the first '[' byte, or the
-// original input when no opening bracket is found. Defends against stray
-// build/restore lines that some dotnet SDKs print to stdout ahead of the
-// extractor's JSON payload, which would otherwise break json.Unmarshal.
-func trimToJSONArray(b []byte) []byte {
-	if i := bytes.IndexByte(b, '['); i > 0 {
-		return b[i:]
+// newExtractorOutputFile creates a unique empty file to receive the JSON
+// payload from the extractor, plus a cleanup function the caller should defer.
+// The file is placed next to the first input file so it lives in a directory
+// the extractor can already access. This matters under WSL + Windows dotnet,
+// where /tmp on the Linux side is not visible to the Windows process.
+func newExtractorOutputFile(files []string) (string, func(), error) {
+	dir := ""
+	if len(files) > 0 {
+		dir = filepath.Dir(files[0])
 	}
-	return b
+	f, err := os.CreateTemp(dir, "valk-guard-csharp-*.json")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create C# extractor output file: %w", err)
+	}
+	path := f.Name()
+	_ = f.Close()
+	return path, func() { _ = os.Remove(path) }, nil
 }
 
 // ensureCachedRoslynExtractorPublished publishes a self-contained extractor

--- a/internal/scanner/csharp/scanner.go
+++ b/internal/scanner/csharp/scanner.go
@@ -222,8 +222,8 @@ func runRoslynProject(ctx context.Context, dotnet, projectPath string, files []s
 	}
 	defer cleanup()
 
-	args := make([]string, 0, 7+len(files))
-	args = append(args, "run", "--project", projectPath, "--verbosity", "quiet", "--", "--output="+pathForDotnet(dotnet, outputPath))
+	args := make([]string, 0, 6+len(files))
+	args = append(args, "run", "--project", projectPath, "--", "--output="+pathForDotnet(dotnet, outputPath))
 	args = append(args, files...)
 	//nolint:gosec // dotnet is a resolved SDK executable and args point at scanner-selected source files.
 	//nolint:gosec // dotnet is a resolved SDK executable used to publish scanner-owned embedded code.
@@ -282,7 +282,7 @@ func runRoslynCommand(cmd *exec.Cmd, ctx context.Context, timeout time.Duration,
 // The file is placed next to the first input file so it lives in a directory
 // the extractor can already access. This matters under WSL + Windows dotnet,
 // where /tmp on the Linux side is not visible to the Windows process.
-func newExtractorOutputFile(files []string) (string, func(), error) {
+func newExtractorOutputFile(files []string) (path string, cleanup func(), err error) {
 	dir := ""
 	if len(files) > 0 {
 		dir = filepath.Dir(files[0])
@@ -291,7 +291,7 @@ func newExtractorOutputFile(files []string) (string, func(), error) {
 	if err != nil {
 		return "", func() {}, fmt.Errorf("create C# extractor output file: %w", err)
 	}
-	path := f.Name()
+	path = f.Name()
 	_ = f.Close()
 	return path, func() { _ = os.Remove(path) }, nil
 }

--- a/internal/scanner/csharp/scanner_test.go
+++ b/internal/scanner/csharp/scanner_test.go
@@ -636,7 +636,7 @@ class Repo {
 		t.Fatalf("write temp file: %v", err)
 	}
 
-	s := &Scanner{DotnetPath: "missing-dotnet-for-test"}
+	s := &Scanner{DotnetPath: "missing-dotnet-for-test", ProjectPath: testRoslynProjectPath()}
 	_, err := scanner.Collect(s.Scan(context.Background(), []string{tmpDir}))
 	if err == nil {
 		t.Fatal("expected missing dotnet error")

--- a/internal/scanner/parity_test.go
+++ b/internal/scanner/parity_test.go
@@ -152,8 +152,7 @@ func scanCSharpParity(t *testing.T, src string) []scannercore.SQLStatement {
 		t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	}
 	writeFile(t, filepath.Join(dir, "Query.cs"), src)
-	project := filepath.Join("csharp", "roslynextractor", "RoslynExtractor.csproj")
-	s := &csharpscanner.Scanner{DotnetPath: os.Getenv("VALK_DOTNET_PATH"), ProjectPath: project}
+	s := &csharpscanner.Scanner{DotnetPath: os.Getenv("VALK_DOTNET_PATH")}
 	stmts, err := scannercore.Collect(s.Scan(context.Background(), []string{dir}))
 	if err != nil {
 		t.Fatalf("csharp scan error: %v", err)


### PR DESCRIPTION
## Summary
- v0.1.4 Release workflow failed in `Run tests` with `decode C# Roslyn extractor output: invalid character '/' looking for beginning of value` (run [26181739758](https://github.com/ValkDB/valk-guard/actions/runs/26181739758/job/77026428182))
- Root cause: the parity test in `internal/scanner/` is the first thing in the CI test run that invokes `dotnet run` against the extractor project, so dotnet writes build/restore diagnostics to stdout ahead of the extractor's JSON payload. `json.Unmarshal` then chokes on the leading characters.
- Pass `--verbosity quiet` to `dotnet run`, and defensively strip any leading bytes before the first `[` before parsing.

## Test plan
- [x] `VALK_DOTNET_PATH=... go test ./internal/scanner/` — all 3 parity sub-tests pass
- [ ] CI on this PR is green
- [ ] After merge, re-tag v0.1.5 (or re-run v0.1.4 release) and confirm GoReleaser succeeds