### PR TITLE
docs: add C# terminal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,19 @@ Most SQL linters use regex. Valk Guard **walks real source structure** instead. 
 
 <table>
 <tr>
-<td width="50%">
+<td width="33%">
 
 **Go + Goqu** — walks builder chains via `go/ast`
 
 </td>
-<td width="50%">
+<td width="33%">
 
 **Python + SQLAlchemy** — parses ORM chains via Python AST
+
+</td>
+<td width="33%">
+
+**C# + EF Core** — extracts raw SQL and deterministic LINQ via Roslyn
 
 </td>
 </tr>
@@ -132,6 +137,11 @@ Most SQL linters use regex. Valk Guard **walks real source structure** instead. 
 <td>
 
 <img src="docs/media/demo-sqlalchemy.svg" alt="SQLAlchemy AST scanning demo" width="100%">
+
+</td>
+<td>
+
+<img src="docs/media/demo-csharp.svg" alt="C# EF Core AST scanning demo" width="100%">
 
 </td>
 </tr>
@@ -227,6 +237,7 @@ See valk-guard reviewing real code in [`ValkDB/valk-guard-example`](https://gith
 - [Schema-drift and DDL rules](https://github.com/ValkDB/valk-guard-example/pull/4)
 - [Query-schema validation (unknown columns/tables)](https://github.com/ValkDB/valk-guard-example/pull/5)
 - [Suppression showcase (inline + global config)](https://github.com/ValkDB/valk-guard-example/pull/6)
+- [C# EF Core query rules](https://github.com/ValkDB/valk-guard-example/pull/10)
 
 ---
 

--- a/docs/media/csharp_example.cs
+++ b/docs/media/csharp_example.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Demo;
+
+public sealed class DangerousQueries
+{
+    public void Run(DbContext db)
+    {
+        // No raw .sql file here - just EF Core calls.
+        // Valk Guard runs a Roslyn AST extractor and catches the problems.
+
+        db.Database.ExecuteSqlRaw("SELECT * FROM users");
+
+        db.Database.ExecuteSqlRaw("UPDATE orders SET status = 'cancelled'");
+
+        db.Database.ExecuteSqlRaw("DELETE FROM sessions");
+
+        db.Users
+            .Where(user => user.Email.Contains("@gmail.com"))
+            .ToList();
+    }
+}

--- a/docs/media/demo-csharp.svg
+++ b/docs/media/demo-csharp.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="944" height="648" viewBox="0 0 944 648" role="img" aria-labelledby="title desc">
+  <title id="title">C# EF Core AST scanning demo</title>
+  <desc id="desc">A terminal-style screenshot showing valk-guard scanning C# EF Core code and reporting SQL findings.</desc>
+  <style>
+    .bg { fill: #282d35; }
+    .muted { fill: #6f7783; font-weight: 700; }
+    .prompt { fill: #a8cc8c; font-weight: 700; }
+    .text { fill: #b9c0cb; }
+    .warn { fill: #dbab79; }
+    .err { fill: #e88388; }
+    text { font-family: Monaco, Consolas, Menlo, "Bitstream Vera Sans Mono", monospace; font-size: 16px; white-space: pre; }
+    .small { font-size: 14px; }
+  </style>
+  <rect width="944" height="648" rx="5" class="bg"/>
+  <circle cx="20" cy="20" r="6" fill="#ff5f58"/>
+  <circle cx="40" cy="20" r="6" fill="#ffbd2e"/>
+  <circle cx="60" cy="20" r="6" fill="#18c132"/>
+
+  <g transform="translate(28 66)">
+    <text x="0" y="0" class="muted"># C# code using EF Core - no .sql file required</text>
+    <text x="0" y="34" class="prompt">❯ </text><text x="24" y="34" class="text">cat csharp_example.cs</text>
+    <text x="0" y="68" class="text">using Microsoft.EntityFrameworkCore;</text>
+    <text x="0" y="102" class="text">namespace Demo;</text>
+    <text x="0" y="136" class="text">public sealed class DangerousQueries</text>
+    <text x="0" y="170" class="text">{</text>
+    <text x="34" y="204" class="text">public void Run(DbContext db)</text>
+    <text x="34" y="238" class="text">{</text>
+    <text x="68" y="272" class="text">// Valk Guard runs a Roslyn AST extractor.</text>
+    <text x="68" y="306" class="text">db.Database.ExecuteSqlRaw("SELECT * FROM users");</text>
+    <text x="68" y="340" class="text">db.Database.ExecuteSqlRaw("UPDATE orders SET status = 'cancelled'");</text>
+    <text x="68" y="374" class="text">db.Database.ExecuteSqlRaw("DELETE FROM sessions");</text>
+    <text x="68" y="408" class="text">db.Users.Where(user =&gt; user.Email.Contains("@gmail.com")).ToList();</text>
+    <text x="34" y="442" class="text">}</text>
+    <text x="0" y="476" class="text">}</text>
+
+    <text x="0" y="504" class="muted"># Valk Guard scans C# syntax, not regex</text>
+    <text x="0" y="532" class="prompt">❯ </text><text x="24" y="532" class="text">valk-guard scan csharp_example.cs</text>
+    <text x="0" y="558" class="text small">demo/csharp_example.cs:12: </text><text x="230" y="558" class="warn small">warning</text><text x="296" y="558" class="text small"> [VG001] avoid SELECT *; project only required columns</text>
+    <text x="0" y="580" class="text small">demo/csharp_example.cs:12: </text><text x="230" y="580" class="warn small">warning</text><text x="296" y="580" class="text small"> [VG004] SELECT without LIMIT may return unbounded rows</text>
+    <text x="0" y="602" class="text small">demo/csharp_example.cs:14: </text><text x="230" y="602" class="err small">error</text><text x="282" y="602" class="text small"> [VG002] UPDATE without WHERE may affect all rows</text>
+    <text x="0" y="624" class="text small">demo/csharp_example.cs:16: </text><text x="230" y="624" class="err small">error</text><text x="282" y="624" class="text small"> [VG003] DELETE without WHERE may affect all rows</text>
+    <text x="0" y="644" class="text small">7 findings</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- add a C# EF Core terminal-style example to the main README alongside Goqu and SQLAlchemy
- add the C# source fixture used by the README media
- link the C# EF Core demo PR from the live demo list

## Verification

- `PATH=/tmp/valk-dotnet-bin:$PATH go run ./cmd/valk-guard scan docs/media/csharp_example.cs --format terminal` produced expected C# findings
- `python3 -c "import xml.etree.ElementTree as ET; ET.parse('docs/media/demo-csharp.svg')"`
- `git diff --check`